### PR TITLE
feat: use standard archive name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,14 +10,6 @@ builds:
       - windows
       - darwin
 
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-
 checksum:
   name_template: "checksums.txt"
 


### PR DESCRIPTION
Easier to download using Go constants such as GOOS and GOARCH.
