### PR TITLE
chore: run buf serially

### DIFF
--- a/.sage/proto.go
+++ b/.sage/proto.go
@@ -12,8 +12,8 @@ import (
 type Proto sg.Namespace
 
 func (Proto) All(ctx context.Context) error {
-	sg.Deps(ctx, Proto.ClangFormatProto, Proto.BufLint, Proto.BufGenerate)
-	sg.Deps(ctx, Proto.BufGenerate, Proto.BufGenerateGoogleapis)
+	sg.Deps(ctx, Proto.ClangFormatProto, Proto.BufLint)
+	sg.SerialDeps(ctx, Proto.BufGenerate, Proto.BufGenerateGoogleapis)
 	return nil
 }
 


### PR DESCRIPTION
Since googleapis module is large, running multiple buf commands in
parallel lead to file locks erroring out because of deadline exceeded.

Also buf generate on the proto files in the repository was done twice.
