### PR TITLE
feat: allow providing a IDGenerator function

### DIFF
--- a/example/freight_service_test.go
+++ b/example/freight_service_test.go
@@ -2,6 +2,8 @@ package example
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	examplefreightv1 "github.com/einride/protoc-gen-go-aip-test/proto/gen/einride/example/freight/v1"
@@ -18,6 +20,9 @@ func Test_FreightService(t *testing.T) {
 		Server: server,
 	}
 
+	// counter to keep track of unique IDs.
+	var idCounter uint64
+
 	// run tests for each resource in the service
 	ctx := context.Background()
 	suite.TestShipper(ctx, examplefreightv1.ShipperTestSuiteConfig{
@@ -28,6 +33,13 @@ func Test_FreightService(t *testing.T) {
 				DisplayName:    "Example shipper",
 				BillingAccount: "billingAccounts/12345",
 			}
+		},
+		// IDGenerator should return a valid and unique ID to use in the Create call.
+		// If non-nil, this function will be called to set the ID on all Create calls.
+		// If the ID field is required, tests will fail if this is nil.
+		IDGenerator: func() string {
+			id := atomic.AddUint64(&idCounter, 1)
+			return fmt.Sprintf("valid-id-%d", id)
 		},
 		// Update should return a resource which is valid to update, i.e.
 		// all required fields set.

--- a/internal/plugin/resource.go
+++ b/internal/plugin/resource.go
@@ -53,7 +53,7 @@ func (r *resourceGenerator) generateFixture(f *protogen.GeneratedFile) {
 		f.P("// provided the test will fail.")
 		f.P("Parents []string")
 	}
-	_, hasCreate := util.StandardMethod(r.service, r.resource, aipreflect.MethodTypeCreate)
+	createMethod, hasCreate := util.StandardMethod(r.service, r.resource, aipreflect.MethodTypeCreate)
 	if hasCreate {
 		f.P("// Create should return a resource which is valid to create, i.e.")
 		f.P("// all required fields set.")
@@ -61,6 +61,13 @@ func (r *resourceGenerator) generateFixture(f *protogen.GeneratedFile) {
 			f.P("Create func(parent string) *", r.message.GoIdent)
 		} else {
 			f.P("Create func() *", r.message.GoIdent)
+		}
+
+		if util.HasUserSettableIDField(r.resource, createMethod.Input.Desc) {
+			f.P("// IDGenerator should return a valid and unique ID to use in the Create call.")
+			f.P("// If non-nil, this function will be called to set the ID on all Create calls.")
+			f.P("// If the ID field is required, tests will fail if this is nil.")
+			f.P("IDGenerator func() string")
 		}
 	} else {
 		f.P("// CreateResource should create a ", r.message.Desc.Name(), " and return it.")

--- a/internal/util/method.go
+++ b/internal/util/method.go
@@ -16,6 +16,15 @@ type MethodCreate struct {
 }
 
 func (m MethodCreate) Generate(f *protogen.GeneratedFile, response, err, assign string) {
+	userSetID := m.UserSettableID
+	if userSetID == "" && HasUserSettableIDField(m.Resource, m.Method.Input.Desc) {
+		userSetID = "userSetID"
+		f.P(userSetID + " := \"\"")
+		f.P("if fx.IDGenerator != nil {")
+		f.P(userSetID + " = fx.IDGenerator()")
+		f.P("}")
+	}
+
 	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.ctx, &", m.Method.Input.GoIdent, "{")
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
@@ -35,9 +44,10 @@ func (m MethodCreate) Generate(f *protogen.GeneratedFile, response, err, assign 
 		f.P(upper, ": fx.Create(", m.Parent, "),")
 	}
 
-	if m.UserSettableID != "" && HasUserSettableIDField(m.Resource, m.Method.Input.Desc) {
-		f.P(upper, "Id: ", m.UserSettableID, ",")
+	if userSetID != "" && HasUserSettableIDField(m.Resource, m.Method.Input.Desc) {
+		f.P(upper, "Id: ", userSetID, ",")
 	}
+
 	f.P("})")
 }
 

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -46,6 +46,10 @@ type ShipperTestSuiteConfig struct {
 	// Create should return a resource which is valid to create, i.e.
 	// all required fields set.
 	Create func() *Shipper
+	// IDGenerator should return a valid and unique ID to use in the Create call.
+	// If non-nil, this function will be called to set the ID on all Create calls.
+	// If the ID field is required, tests will fail if this is nil.
+	IDGenerator func() string
 	// Update should return a resource which is valid to update, i.e.
 	// all required fields set.
 	Update func() *Shipper
@@ -68,8 +72,13 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 	// Field create_time should be populated when the resource is created.
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
+		userSetID := ""
+		if fx.IDGenerator != nil {
+			userSetID = fx.IDGenerator()
+		}
 		msg, err := fx.service.CreateShipper(fx.ctx, &CreateShipperRequest{
-			Shipper: fx.Create(),
+			Shipper:   fx.Create(),
+			ShipperId: userSetID,
 		})
 		assert.NilError(t, err)
 		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
@@ -78,8 +87,13 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 	// The created resource should be persisted and reachable with Get.
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
+		userSetID := ""
+		if fx.IDGenerator != nil {
+			userSetID = fx.IDGenerator()
+		}
 		msg, err := fx.service.CreateShipper(fx.ctx, &CreateShipperRequest{
-			Shipper: fx.Create(),
+			Shipper:   fx.Create(),
+			ShipperId: userSetID,
 		})
 		assert.NilError(t, err)
 		persisted, err := fx.service.GetShipper(fx.ctx, &GetShipperRequest{
@@ -130,8 +144,13 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
+			userSetID := ""
+			if fx.IDGenerator != nil {
+				userSetID = fx.IDGenerator()
+			}
 			_, err := fx.service.CreateShipper(fx.ctx, &CreateShipperRequest{
-				Shipper: msg,
+				Shipper:   msg,
+				ShipperId: userSetID,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
 		})
@@ -144,8 +163,13 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("billing_account")
 			container.ProtoReflect().Clear(fd)
+			userSetID := ""
+			if fx.IDGenerator != nil {
+				userSetID = fx.IDGenerator()
+			}
 			_, err := fx.service.CreateShipper(fx.ctx, &CreateShipperRequest{
-				Shipper: msg,
+				Shipper:   msg,
+				ShipperId: userSetID,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
 		})
@@ -163,8 +187,13 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.BillingAccount = "invalid resource name"
+			userSetID := ""
+			if fx.IDGenerator != nil {
+				userSetID = fx.IDGenerator()
+			}
 			_, err := fx.service.CreateShipper(fx.ctx, &CreateShipperRequest{
-				Shipper: msg,
+				Shipper:   msg,
+				ShipperId: userSetID,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
 		})
@@ -395,8 +424,13 @@ func (fx *ShipperTestSuiteConfig) maybeSkip(t *testing.T) {
 
 func (fx *ShipperTestSuiteConfig) create(t *testing.T) *Shipper {
 	t.Helper()
+	userSetID := ""
+	if fx.IDGenerator != nil {
+		userSetID = fx.IDGenerator()
+	}
 	created, err := fx.service.CreateShipper(fx.ctx, &CreateShipperRequest{
-		Shipper: fx.Create(),
+		Shipper:   fx.Create(),
+		ShipperId: userSetID,
 	})
 	assert.NilError(t, err)
 	return created


### PR DESCRIPTION
For services with user-settable IDs, there might be requirements on how the format of that ID should look. Providing this function, i.e. it is non-nil, will call it and fill in the returned ID during creation steps.

It is expected (and documented) that the function should return unique IDs. It is up to the user to fulfill this requirement. One provided example is to use a counter and include that in the ID.

This feature makes it possible to use this test suite for APIs where user-settable ID is required, which wasn't possible before.