### PR TITLE
Fixes flaky tests due to timing issues in podman or colima

### DIFF
--- a/internal/aiptest/create/create_time.go
+++ b/internal/aiptest/create/create_time.go
@@ -33,7 +33,10 @@ var createTime = suite.Test{
 			Parent:   "parent",
 		}.Generate(f, "msg", "err", ":=")
 		f.P(ident.AssertNilError, "(t, err)")
-		f.P(ident.AssertCheck, "(t, ", ident.TimeSince, "(msg.CreateTime.AsTime()) < ", ident.TimeSecond, ")")
+		f.P(ident.AssertCheck, "(t, msg.CreateTime != nil)")
+		f.P(ident.AssertCheck, "(t, !msg.CreateTime.AsTime().IsZero())")
+		// Allow Created == Now due to flakyness of clock in podman and colima
+		f.P(ident.AssertCheck, "(t, !msg.CreateTime.AsTime().After(", ident.TimeNow, "()))")
 		return nil
 	},
 }

--- a/internal/aiptest/update/update_time.go
+++ b/internal/aiptest/update/update_time.go
@@ -38,7 +38,8 @@ var updateTime = suite.Test{
 			Msg:      "created",
 		}.Generate(f, "updated", "err", ":=")
 		f.P(ident.AssertNilError, "(t, err)")
-		f.P(ident.AssertCheck, "(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))")
+		// Allow Created == Updated due to flakyness of clock in podman and colima
+		f.P(ident.AssertCheck, "(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))")
 		return nil
 	},
 }

--- a/internal/ident/time.go
+++ b/internal/ident/time.go
@@ -10,4 +10,5 @@ import (
 var (
 	TimeSecond = protogen.GoIdent{GoName: "Second", GoImportPath: "time"}
 	TimeSince  = protogen.GoIdent{GoName: "Since", GoImportPath: "time"}
+	TimeNow    = protogen.GoIdent{GoName: "Now", GoImportPath: "time"}
 )

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -82,7 +82,9 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 			ShipperId: userSetID,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -286,7 +288,7 @@ func (fx *ShipperTestSuiteConfig) testUpdate(t *testing.T) {
 			Shipper: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
+		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -551,7 +553,9 @@ func (fx *SiteTestSuiteConfig) testCreate(t *testing.T) {
 			Site:   fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -871,7 +875,7 @@ func (fx *SiteTestSuiteConfig) testUpdate(t *testing.T) {
 			Site: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
+		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
@@ -136,7 +136,9 @@ func (fx *BatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) {
 			BatchPredictionJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -813,7 +815,9 @@ func (fx *CustomJobTestSuiteConfig) testCreate(t *testing.T) {
 			CustomJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1327,7 +1331,9 @@ func (fx *DataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 			DataLabelingJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1828,7 +1834,9 @@ func (fx *HyperparameterTuningJobTestSuiteConfig) testCreate(t *testing.T) {
 			HyperparameterTuningJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -2426,7 +2434,9 @@ func (fx *ModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *testing.T) 
 			ModelDeploymentMonitoringJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -3156,7 +3166,9 @@ func (fx *NasJobTestSuiteConfig) testCreate(t *testing.T) {
 			NasJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
@@ -123,7 +123,9 @@ func (fx *ArtifactTestSuiteConfig) testCreate(t *testing.T) {
 			Artifact: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -233,7 +235,7 @@ func (fx *ArtifactTestSuiteConfig) testUpdate(t *testing.T) {
 			Artifact: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
+		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -572,7 +574,9 @@ func (fx *ContextTestSuiteConfig) testCreate(t *testing.T) {
 			Context: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -682,7 +686,7 @@ func (fx *ContextTestSuiteConfig) testUpdate(t *testing.T) {
 			Context: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
+		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -1021,7 +1025,9 @@ func (fx *ExecutionTestSuiteConfig) testCreate(t *testing.T) {
 			Execution: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1131,7 +1137,7 @@ func (fx *ExecutionTestSuiteConfig) testUpdate(t *testing.T) {
 			Execution: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
+		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -1465,7 +1471,9 @@ func (fx *MetadataSchemaTestSuiteConfig) testCreate(t *testing.T) {
 			MetadataSchema: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
@@ -94,7 +94,9 @@ func (fx *PipelineJobTestSuiteConfig) testCreate(t *testing.T) {
 			PipelineJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -515,7 +517,9 @@ func (fx *TrainingPipelineTestSuiteConfig) testCreate(t *testing.T) {
 			TrainingPipeline: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
@@ -92,7 +92,9 @@ func (fx *ScheduleTestSuiteConfig) testCreate(t *testing.T) {
 			Schedule: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -340,7 +342,7 @@ func (fx *ScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 			Schedule: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
+		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
@@ -587,7 +587,9 @@ func (fx *TensorboardExperimentTestSuiteConfig) testCreate(t *testing.T) {
 			TensorboardExperiment: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -697,7 +699,7 @@ func (fx *TensorboardExperimentTestSuiteConfig) testUpdate(t *testing.T) {
 			TensorboardExperiment: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
+		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -1036,7 +1038,9 @@ func (fx *TensorboardRunTestSuiteConfig) testCreate(t *testing.T) {
 			TensorboardRun: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1168,7 +1172,7 @@ func (fx *TensorboardRunTestSuiteConfig) testUpdate(t *testing.T) {
 			TensorboardRun: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
+		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -1550,7 +1554,9 @@ func (fx *TensorboardTimeSeriesTestSuiteConfig) testCreate(t *testing.T) {
 			TensorboardTimeSeries: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1698,7 +1704,7 @@ func (fx *TensorboardTimeSeriesTestSuiteConfig) testUpdate(t *testing.T) {
 			TensorboardTimeSeries: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
+		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
@@ -94,7 +94,9 @@ func (fx *StudyTestSuiteConfig) testCreate(t *testing.T) {
 			Study:  fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		assert.Check(t, time.Since(msg.CreateTime.AsTime()) < time.Second)
+		assert.Check(t, msg.CreateTime != nil)
+		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
+		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
 	})
 
 	// The created resource should be persisted and reachable with Get.


### PR DESCRIPTION
Avoids testing that the clock actually ticks between create and get in the test VM. Having hard requirements on actual clock tick introduces some flakyness in some docker alternatives on mac like podman and colima.