### PR TITLE
Reverted change to update_time test

### DIFF
--- a/internal/aiptest/update/update_time.go
+++ b/internal/aiptest/update/update_time.go
@@ -38,8 +38,7 @@ var updateTime = suite.Test{
 			Msg:      "created",
 		}.Generate(f, "updated", "err", ":=")
 		f.P(ident.AssertNilError, "(t, err)")
-		// Allow Created == Updated due to flakyness of clock in podman and colima
-		f.P(ident.AssertCheck, "(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))")
+		f.P(ident.AssertCheck, "(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))")
 		return nil
 	},
 }

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -288,7 +288,7 @@ func (fx *ShipperTestSuiteConfig) testUpdate(t *testing.T) {
 			Shipper: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
+		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -875,7 +875,7 @@ func (fx *SiteTestSuiteConfig) testUpdate(t *testing.T) {
 			Site: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
+		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
@@ -235,7 +235,7 @@ func (fx *ArtifactTestSuiteConfig) testUpdate(t *testing.T) {
 			Artifact: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
+		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -686,7 +686,7 @@ func (fx *ContextTestSuiteConfig) testUpdate(t *testing.T) {
 			Context: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
+		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -1137,7 +1137,7 @@ func (fx *ExecutionTestSuiteConfig) testUpdate(t *testing.T) {
 			Execution: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
+		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
@@ -342,7 +342,7 @@ func (fx *ScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 			Schedule: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
+		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
@@ -699,7 +699,7 @@ func (fx *TensorboardExperimentTestSuiteConfig) testUpdate(t *testing.T) {
 			TensorboardExperiment: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
+		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -1172,7 +1172,7 @@ func (fx *TensorboardRunTestSuiteConfig) testUpdate(t *testing.T) {
 			TensorboardRun: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
+		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.
@@ -1704,7 +1704,7 @@ func (fx *TensorboardTimeSeriesTestSuiteConfig) testUpdate(t *testing.T) {
 			TensorboardTimeSeries: created,
 		})
 		assert.NilError(t, err)
-		assert.Check(t, !created.UpdateTime.AsTime().After(updated.UpdateTime.AsTime()))
+		assert.Check(t, updated.UpdateTime.AsTime().After(created.UpdateTime.AsTime()))
 	})
 
 	// The updated resource should be persisted and reachable with Get.


### PR DESCRIPTION
This PR reverts AIP update_time test assertion. The test should assert UpdateTime is changed after an update is performed.