### PR TITLE
Another stab at getting rid of macOS/podman/colima flaky tests

### DIFF
--- a/internal/aiptest/create/create_time.go
+++ b/internal/aiptest/create/create_time.go
@@ -27,6 +27,7 @@ var createTime = suite.Test{
 		if util.HasParent(scope.Resource) {
 			f.P("parent := ", ident.FixtureNextParent, "(t, false)")
 		}
+		f.P("beforeCreate := ", ident.TimeNow, "()")
 		util.MethodCreate{
 			Resource: scope.Resource,
 			Method:   createMethod,
@@ -35,8 +36,13 @@ var createTime = suite.Test{
 		f.P(ident.AssertNilError, "(t, err)")
 		f.P(ident.AssertCheck, "(t, msg.CreateTime != nil)")
 		f.P(ident.AssertCheck, "(t, !msg.CreateTime.AsTime().IsZero())")
-		// Allow Created == Now due to flakyness of clock in podman and colima
-		f.P(ident.AssertCheck, "(t, !msg.CreateTime.AsTime().After(", ident.TimeNow, "()))")
+		f.P("if ", protogen.GoIdent{GoImportPath: "runtime", GoName: "GOOS"}, " == \"darwin\" {")
+		// Allow Created == Now+1s due to flakyness of clock in podman and colima.
+		f.P(ident.AssertCheck, "(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1 * ", ident.TimeSecond, ")))")
+		f.P("} else {")
+		// Enforce tighter check on Linux.
+		f.P(ident.AssertCheck, "(t, msg.CreateTime.AsTime().After(beforeCreate))")
+		f.P("}")
 		return nil
 	},
 }

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -11,6 +11,7 @@ import (
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	assert "gotest.tools/v3/assert"
+	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -73,6 +74,7 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 	// Field create_time should be populated when the resource is created.
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
+		beforeCreate := time.Now()
 		userSetID := ""
 		if fx.IDGenerator != nil {
 			userSetID = fx.IDGenerator()
@@ -84,7 +86,11 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -548,6 +554,7 @@ func (fx *SiteTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateSite(fx.ctx, &CreateSiteRequest{
 			Parent: parent,
 			Site:   fx.Create(parent),
@@ -555,7 +562,11 @@ func (fx *SiteTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
@@ -11,6 +11,7 @@ import (
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	assert "gotest.tools/v3/assert"
+	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -131,6 +132,7 @@ func (fx *BatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
 			Parent:             parent,
 			BatchPredictionJob: fx.Create(parent),
@@ -138,7 +140,11 @@ func (fx *BatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -810,6 +816,7 @@ func (fx *CustomJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
 			Parent:    parent,
 			CustomJob: fx.Create(parent),
@@ -817,7 +824,11 @@ func (fx *CustomJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1326,6 +1337,7 @@ func (fx *DataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
 			Parent:          parent,
 			DataLabelingJob: fx.Create(parent),
@@ -1333,7 +1345,11 @@ func (fx *DataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1829,6 +1845,7 @@ func (fx *HyperparameterTuningJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
 			Parent:                  parent,
 			HyperparameterTuningJob: fx.Create(parent),
@@ -1836,7 +1853,11 @@ func (fx *HyperparameterTuningJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -2429,6 +2450,7 @@ func (fx *ModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *testing.T) 
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
 			Parent:                       parent,
 			ModelDeploymentMonitoringJob: fx.Create(parent),
@@ -2436,7 +2458,11 @@ func (fx *ModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *testing.T) 
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -3161,6 +3187,7 @@ func (fx *NasJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
 			Parent: parent,
 			NasJob: fx.Create(parent),
@@ -3168,7 +3195,11 @@ func (fx *NasJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
@@ -10,6 +10,7 @@ import (
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	assert "gotest.tools/v3/assert"
+	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -118,6 +119,7 @@ func (fx *ArtifactTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateArtifact(fx.ctx, &CreateArtifactRequest{
 			Parent:   parent,
 			Artifact: fx.Create(parent),
@@ -125,7 +127,11 @@ func (fx *ArtifactTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -569,6 +575,7 @@ func (fx *ContextTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateContext(fx.ctx, &CreateContextRequest{
 			Parent:  parent,
 			Context: fx.Create(parent),
@@ -576,7 +583,11 @@ func (fx *ContextTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1020,6 +1031,7 @@ func (fx *ExecutionTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateExecution(fx.ctx, &CreateExecutionRequest{
 			Parent:    parent,
 			Execution: fx.Create(parent),
@@ -1027,7 +1039,11 @@ func (fx *ExecutionTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1466,6 +1482,7 @@ func (fx *MetadataSchemaTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateMetadataSchema(fx.ctx, &CreateMetadataSchemaRequest{
 			Parent:         parent,
 			MetadataSchema: fx.Create(parent),
@@ -1473,7 +1490,11 @@ func (fx *MetadataSchemaTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
@@ -9,6 +9,7 @@ import (
 	status "google.golang.org/grpc/status"
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	assert "gotest.tools/v3/assert"
+	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -89,6 +90,7 @@ func (fx *PipelineJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreatePipelineJob(fx.ctx, &CreatePipelineJobRequest{
 			Parent:      parent,
 			PipelineJob: fx.Create(parent),
@@ -96,7 +98,11 @@ func (fx *PipelineJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -512,6 +518,7 @@ func (fx *TrainingPipelineTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateTrainingPipeline(fx.ctx, &CreateTrainingPipelineRequest{
 			Parent:           parent,
 			TrainingPipeline: fx.Create(parent),
@@ -519,7 +526,11 @@ func (fx *TrainingPipelineTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
@@ -11,6 +11,7 @@ import (
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	assert "gotest.tools/v3/assert"
+	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -582,6 +583,7 @@ func (fx *TensorboardExperimentTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateTensorboardExperiment(fx.ctx, &CreateTensorboardExperimentRequest{
 			Parent:                parent,
 			TensorboardExperiment: fx.Create(parent),
@@ -589,7 +591,11 @@ func (fx *TensorboardExperimentTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1033,6 +1039,7 @@ func (fx *TensorboardRunTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateTensorboardRun(fx.ctx, &CreateTensorboardRunRequest{
 			Parent:         parent,
 			TensorboardRun: fx.Create(parent),
@@ -1040,7 +1047,11 @@ func (fx *TensorboardRunTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1549,6 +1560,7 @@ func (fx *TensorboardTimeSeriesTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateTensorboardTimeSeries(fx.ctx, &CreateTensorboardTimeSeriesRequest{
 			Parent:                parent,
 			TensorboardTimeSeries: fx.Create(parent),
@@ -1556,7 +1568,11 @@ func (fx *TensorboardTimeSeriesTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
@@ -9,6 +9,7 @@ import (
 	status "google.golang.org/grpc/status"
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	assert "gotest.tools/v3/assert"
+	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -89,6 +90,7 @@ func (fx *StudyTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("create time", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
+		beforeCreate := time.Now()
 		msg, err := fx.service.CreateStudy(fx.ctx, &CreateStudyRequest{
 			Parent: parent,
 			Study:  fx.Create(parent),
@@ -96,7 +98,11 @@ func (fx *StudyTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, !msg.CreateTime.AsTime().After(time.Now()))
+		if runtime.GOOS == "darwin" {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
+		} else {
+			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		}
 	})
 
 	// The created resource should be persisted and reachable with Get.


### PR DESCRIPTION
### Why?

@gustavs tried to fix a "flaky test" problem but I still see errors when running tests on macOS with podman.

```
xxx_service_aiptest.pb.go:92: assertion failed: msg.CreateTime.AsTime().After(time.Now()) is true
```



### What?

It _seems_ that if we add 1 second to this particular assertion, these tests passes on macOS/podman. So;
- Assert that created time is not after Now + 1s (on macOS only).
- Bring back original assertion (not to be run on macOS).

### Notes, concerns, side-effects etc

- Previous PRs attempting to address this:
  - #211
  - #212
- Side-note: I'm getting a bunch of errors when I run `make` in the root of the project (with go 1.19.12 on `$PATH`) for some reason. This doesn't seem normal...
