### PR TITLE
Remove macOS-specific assertion

### DIFF
--- a/internal/aiptest/create/create_time.go
+++ b/internal/aiptest/create/create_time.go
@@ -36,13 +36,7 @@ var createTime = suite.Test{
 		f.P(ident.AssertNilError, "(t, err)")
 		f.P(ident.AssertCheck, "(t, msg.CreateTime != nil)")
 		f.P(ident.AssertCheck, "(t, !msg.CreateTime.AsTime().IsZero())")
-		f.P("if ", protogen.GoIdent{GoImportPath: "runtime", GoName: "GOOS"}, " == \"darwin\" {")
-		// Allow Created == Now+1s due to flakyness of clock in podman and colima.
-		f.P(ident.AssertCheck, "(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1 * ", ident.TimeSecond, ")))")
-		f.P("} else {")
-		// Enforce tighter check on Linux.
 		f.P(ident.AssertCheck, "(t, msg.CreateTime.AsTime().After(beforeCreate))")
-		f.P("}")
 		return nil
 	},
 }

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -11,7 +11,6 @@ import (
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	assert "gotest.tools/v3/assert"
-	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -86,11 +85,7 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -562,11 +557,7 @@ func (fx *SiteTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
@@ -11,7 +11,6 @@ import (
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	assert "gotest.tools/v3/assert"
-	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -140,11 +139,7 @@ func (fx *BatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -824,11 +819,7 @@ func (fx *CustomJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1345,11 +1336,7 @@ func (fx *DataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1853,11 +1840,7 @@ func (fx *HyperparameterTuningJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -2458,11 +2441,7 @@ func (fx *ModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *testing.T) 
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -3195,11 +3174,7 @@ func (fx *NasJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
@@ -10,7 +10,6 @@ import (
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	assert "gotest.tools/v3/assert"
-	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -127,11 +126,7 @@ func (fx *ArtifactTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -583,11 +578,7 @@ func (fx *ContextTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1039,11 +1030,7 @@ func (fx *ExecutionTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1490,11 +1477,7 @@ func (fx *MetadataSchemaTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
@@ -9,7 +9,6 @@ import (
 	status "google.golang.org/grpc/status"
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	assert "gotest.tools/v3/assert"
-	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -98,11 +97,7 @@ func (fx *PipelineJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -526,11 +521,7 @@ func (fx *TrainingPipelineTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
@@ -11,7 +11,6 @@ import (
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	assert "gotest.tools/v3/assert"
-	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -96,11 +95,7 @@ func (fx *ScheduleTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
@@ -11,7 +11,6 @@ import (
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 	assert "gotest.tools/v3/assert"
-	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -591,11 +590,7 @@ func (fx *TensorboardExperimentTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1047,11 +1042,7 @@ func (fx *TensorboardRunTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1568,11 +1559,7 @@ func (fx *TensorboardTimeSeriesTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
@@ -9,7 +9,6 @@ import (
 	status "google.golang.org/grpc/status"
 	protocmp "google.golang.org/protobuf/testing/protocmp"
 	assert "gotest.tools/v3/assert"
-	runtime "runtime"
 	strings "strings"
 	testing "testing"
 	time "time"
@@ -98,11 +97,7 @@ func (fx *StudyTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		if runtime.GOOS == "darwin" {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate.Add(1*time.Second)))
-		} else {
-			assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
-		}
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
 	})
 
 	// The created resource should be persisted and reachable with Get.


### PR DESCRIPTION
### Why?

In an attempt to fix a flaky test on macOS (in #213), we introduced an if-condition that asserts differently on macOS vs other operating systems. During review, we mucked around with the assertions and managed to merge an assertion for macOS which was weird (brain fart) and kept causing failing tests. 🤦

### What?

- Remove the if-condition and the macOS-specific assertion, as the assertion for Linux also works fine on macOS.





### Notes, concerns, side-effects etc

- There is no need to have different assertions per-operating system. I have verified this in an internal project on my M2 Macbook Pro, and I ran the test suite 10 times without a single failing test. 🎉
- If this somehow ends up still not working fine... I guess I'll have to eat my hat.
