### PR TITLE
Show improved assertion error message

### DIFF
--- a/internal/aiptest/create/create_time.go
+++ b/internal/aiptest/create/create_time.go
@@ -36,7 +36,11 @@ var createTime = suite.Test{
 		f.P(ident.AssertNilError, "(t, err)")
 		f.P(ident.AssertCheck, "(t, msg.CreateTime != nil)")
 		f.P(ident.AssertCheck, "(t, !msg.CreateTime.AsTime().IsZero())")
-		f.P(ident.AssertCheck, "(t, msg.CreateTime.AsTime().After(beforeCreate))")
+		f.P(
+			ident.AssertCheck,
+			"(t, msg.CreateTime.AsTime().After(beforeCreate), ",
+			"\"msg.CreateTime (%v) is not after beforeCreate (%v)\", msg.CreateTime.AsTime(), beforeCreate)",
+		)
 		return nil
 	},
 }

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -85,7 +85,7 @@ func (fx *ShipperTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -557,7 +557,7 @@ func (fx *SiteTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
@@ -139,7 +139,7 @@ func (fx *BatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -819,7 +819,7 @@ func (fx *CustomJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1336,7 +1336,7 @@ func (fx *DataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1840,7 +1840,7 @@ func (fx *HyperparameterTuningJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -2441,7 +2441,7 @@ func (fx *ModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *testing.T) 
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -3174,7 +3174,7 @@ func (fx *NasJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
@@ -126,7 +126,7 @@ func (fx *ArtifactTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -578,7 +578,7 @@ func (fx *ContextTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1030,7 +1030,7 @@ func (fx *ExecutionTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1477,7 +1477,7 @@ func (fx *MetadataSchemaTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
@@ -97,7 +97,7 @@ func (fx *PipelineJobTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -521,7 +521,7 @@ func (fx *TrainingPipelineTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
@@ -95,7 +95,7 @@ func (fx *ScheduleTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
@@ -590,7 +590,7 @@ func (fx *TensorboardExperimentTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1042,7 +1042,7 @@ func (fx *TensorboardRunTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.
@@ -1559,7 +1559,7 @@ func (fx *TensorboardTimeSeriesTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
@@ -97,7 +97,7 @@ func (fx *StudyTestSuiteConfig) testCreate(t *testing.T) {
 		assert.NilError(t, err)
 		assert.Check(t, msg.CreateTime != nil)
 		assert.Check(t, !msg.CreateTime.AsTime().IsZero())
-		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+		assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
 	})
 
 	// The created resource should be persisted and reachable with Get.


### PR DESCRIPTION

Basically, I introduced this diff to better show what "want" vs "got" values were:

```diff
-	assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate))
+	assert.Check(t, msg.CreateTime.AsTime().After(beforeCreate), "msg.CreateTime (%v) is not after beforeCreate (%v)", msg.CreateTime.AsTime(), beforeCreate)
```


[TRA-1124]: https://einride.atlassian.net/browse/TRA-1124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ