### PR TITLE
feat(get): return resource even if soft-deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,14 @@ Sample skips:
 
 ### Get
 
-| Name           | Description                                                                                | Only if                                                          |
-| -------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| missing name   | Method should fail with InvalidArgument if no name is provided.                            | Generated only if all are true: <ul><li>has Get method</li></ul> |
-| invalid name   | Method should fail with InvalidArgument if the provided name is not valid.                 | Generated only if all are true: <ul><li>has Get method</li></ul> |
-| exists         | Resource should be returned without errors if it exists.                                   | Generated only if all are true: <ul><li>has Get method</li></ul> |
-| not found      | Method should fail with NotFound if the resource does not exist.                           | Generated only if all are true: <ul><li>has Get method</li></ul> |
-| only wildcards | Method should fail with InvalidArgument if the provided name only contains wildcards ('-') | Generated only if all are true: <ul><li>has Get method</li></ul> |
+| Name           | Description                                                                                | Only if                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| missing name   | Method should fail with InvalidArgument if no name is provided.                            | Generated only if all are true: <ul><li>has Get method</li></ul>                                                           |
+| invalid name   | Method should fail with InvalidArgument if the provided name is not valid.                 | Generated only if all are true: <ul><li>has Get method</li></ul>                                                           |
+| exists         | Resource should be returned without errors if it exists.                                   | Generated only if all are true: <ul><li>has Get method</li></ul>                                                           |
+| not found      | Method should fail with NotFound if the resource does not exist.                           | Generated only if all are true: <ul><li>has Get method</li></ul>                                                           |
+| only wildcards | Method should fail with InvalidArgument if the provided name only contains wildcards ('-') | Generated only if all are true: <ul><li>has Get method</li></ul>                                                           |
+| soft-deleted   | A soft-deleted resource should be returned without errors.                                 | Generated only if all are true: <ul><li>has Get method</li><li>has Delete method</li><li>has field 'delete_time'</li></ul> |
 
 ### BatchGet
 

--- a/internal/aiptest/get/deleted.go
+++ b/internal/aiptest/get/deleted.go
@@ -1,0 +1,48 @@
+package get
+
+import (
+	"github.com/einride/protoc-gen-go-aip-test/internal/ident"
+	"github.com/einride/protoc-gen-go-aip-test/internal/onlyif"
+	"github.com/einride/protoc-gen-go-aip-test/internal/suite"
+	"github.com/einride/protoc-gen-go-aip-test/internal/util"
+	"go.einride.tech/aip/reflect/aipreflect"
+	"google.golang.org/protobuf/compiler/protogen"
+)
+
+//nolint:gochecknoglobals
+var softDeleted = suite.Test{
+	Name: "soft-deleted",
+	Doc: []string{
+		"A soft-deleted resource should be returned without errors.",
+	},
+	OnlyIf: suite.OnlyIfs(
+		onlyif.HasMethod(aipreflect.MethodTypeGet),
+		onlyif.HasMethod(aipreflect.MethodTypeDelete),
+		onlyif.HasField("delete_time"),
+	),
+	Generate: func(f *protogen.GeneratedFile, scope suite.Scope) error {
+		getMethod, _ := util.StandardMethod(scope.Service, scope.Resource, aipreflect.MethodTypeGet)
+		deleteMethod, _ := util.StandardMethod(scope.Service, scope.Resource, aipreflect.MethodTypeDelete)
+
+		if util.HasParent(scope.Resource) {
+			f.P("parent := ", ident.FixtureNextParent, "(t, false)")
+			f.P("created := fx.create(t, parent)")
+		} else {
+			f.P("created := fx.create(t)")
+		}
+		util.MethodDelete{
+			Resource:    scope.Resource,
+			Method:      deleteMethod,
+			ResourceVar: "created",
+		}.Generate(f, "deleted", "err", ":=")
+		f.P(ident.AssertNilError, "(t, err)")
+		util.MethodGet{
+			Resource: scope.Resource,
+			Method:   getMethod,
+			Name:     "created.Name",
+		}.Generate(f, "msg", "err", ":=")
+		f.P(ident.AssertNilError, "(t, err)")
+		f.P(ident.AssertDeepEqual, "(t, msg, deleted, ", ident.ProtocmpTransform, "())")
+		return nil
+	},
+}

--- a/internal/aiptest/get/get.go
+++ b/internal/aiptest/get/get.go
@@ -15,5 +15,6 @@ var Suite = suite.Suite{
 		exists,
 		notFound,
 		wildcardName,
+		softDeleted,
 	},
 }

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -269,6 +269,21 @@ func (fx *FreightServiceShipperTestSuiteConfig) testGet(t *testing.T) {
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
 	})
 
+	// A soft-deleted resource should be returned without errors.
+	t.Run("soft-deleted", func(t *testing.T) {
+		fx.maybeSkip(t)
+		created := fx.create(t)
+		deleted, err := fx.service.DeleteShipper(fx.ctx, &DeleteShipperRequest{
+			Name: created.Name,
+		})
+		assert.NilError(t, err)
+		msg, err := fx.service.GetShipper(fx.ctx, &GetShipperRequest{
+			Name: created.Name,
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, msg, deleted, protocmp.Transform())
+	})
+
 }
 
 func (fx *FreightServiceShipperTestSuiteConfig) testUpdate(t *testing.T) {
@@ -763,6 +778,23 @@ func (fx *FreightServiceSiteTestSuiteConfig) testGet(t *testing.T) {
 			Name: "shippers/-/sites/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
+	})
+
+	// A soft-deleted resource should be returned without errors.
+	t.Run("soft-deleted", func(t *testing.T) {
+		fx.maybeSkip(t)
+		parent := fx.nextParent(t, false)
+		created := fx.create(t, parent)
+		deleted, err := fx.service.DeleteSite(fx.ctx, &DeleteSiteRequest{
+			Name: created.Name,
+			Etag: created.Etag,
+		})
+		assert.NilError(t, err)
+		msg, err := fx.service.GetSite(fx.ctx, &GetSiteRequest{
+			Name: created.Name,
+		})
+		assert.NilError(t, err)
+		assert.DeepEqual(t, msg, deleted, protocmp.Transform())
 	})
 
 }


### PR DESCRIPTION
From [AIP-164](https://google.aip.dev/164) documentation:
```
Get ([AIP-131](https://google.aip.dev/131)) requests for soft-deleted resources should return the resource (rather than a NOT_FOUND error).
```