### PR TITLE
feat: alternative way to bootstrap the tests

### DIFF
--- a/example/freight_service_test.go
+++ b/example/freight_service_test.go
@@ -51,3 +51,22 @@ func Test_FreightService(t *testing.T) {
 		},
 	})
 }
+
+func Test_FreightService_AlternativeSetup(t *testing.T) {
+	// Even though no implementation exists, the tests will pass but be skipped.
+	examplefreightv1.TestFreightService(t, &aipTests{})
+}
+
+type aipTests struct{}
+
+var _ examplefreightv1.FreightServiceTestSuiteConfigProvider = &aipTests{}
+
+func (a aipTests) ShipperTestSuiteConfig(_ *testing.T) *examplefreightv1.FreightServiceShipperTestSuiteConfig {
+	// Returns nil to indicate that it's not ready to be tested.
+	return nil
+}
+
+func (a aipTests) SiteTestSuiteConfig(_ *testing.T) *examplefreightv1.FreightServiceSiteTestSuiteConfig {
+	// Returns nil to indicate that it's not ready to be tested.
+	return nil
+}

--- a/internal/plugin/name.go
+++ b/internal/plugin/name.go
@@ -14,9 +14,20 @@ func serviceTestSuiteName(service protoreflect.ServiceDescriptor) string {
 	return string(service.Name()) + "TestSuite"
 }
 
+func serviceResourceName(
+	service protoreflect.ServiceDescriptor,
+	resource *annotations.ResourceDescriptor,
+) string {
+	return string(service.Name()) + resourceType(resource)
+}
+
 func resourceTestSuiteConfigName(
 	service protoreflect.ServiceDescriptor,
 	resource *annotations.ResourceDescriptor,
 ) string {
-	return string(service.Name()) + resourceType(resource) + "TestSuiteConfig"
+	return serviceResourceName(service, resource) + "TestSuiteConfig"
+}
+
+func serviceTestConfigSupplierName(service protoreflect.ServiceDescriptor) string {
+	return string(service.Name()) + "TestSuiteConfigProvider"
 }

--- a/internal/plugin/resource.go
+++ b/internal/plugin/resource.go
@@ -41,10 +41,12 @@ func (r *resourceGenerator) generateFixture(f *protogen.GeneratedFile) {
 	})
 
 	f.P("type ", resourceTestSuiteConfigName(r.service.Desc, r.resource), " struct {")
-	f.P("service ", service)
 	f.P("currParent int")
 	f.P()
 
+	f.P("// Service should return the service that should be tested.")
+	f.P("// The service will be used for several tests.")
+	f.P("Service", " func() ", service)
 	f.P("// Context should return a new context.")
 	f.P("// The context will be used for several tests.")
 	f.P("Context", " func() ", context)

--- a/internal/plugin/resource.go
+++ b/internal/plugin/resource.go
@@ -41,11 +41,13 @@ func (r *resourceGenerator) generateFixture(f *protogen.GeneratedFile) {
 	})
 
 	f.P("type ", resourceTestSuiteConfigName(r.service.Desc, r.resource), " struct {")
-	f.P("ctx ", context)
 	f.P("service ", service)
 	f.P("currParent int")
 	f.P()
 
+	f.P("// Context should return a new context.")
+	f.P("// The context will be used for several tests.")
+	f.P("Context", " func() ", context)
 	if util.HasParent(r.resource) {
 		f.P("// The parents to use when creating resources.")
 		f.P("// At least one parent needs to be set. Depending on methods available on the resource,")
@@ -239,7 +241,7 @@ func (r *resourceGenerator) generateCreate(f *protogen.GeneratedFile) {
 		f.P("if fx.CreateResource == nil {")
 		f.P("t.Skip(\"Test skipped because CreateResource not specified on ", fixtureName, "\")")
 		f.P("}")
-		f.P("created, err := fx.CreateResource(fx.ctx", parentCallArg, ")")
+		f.P("created, err := fx.CreateResource(fx.Context()", parentCallArg, ")")
 		f.P(ident.AssertNilError, "(t, err)")
 		f.P("return created")
 	}

--- a/internal/plugin/service.go
+++ b/internal/plugin/service.go
@@ -65,7 +65,7 @@ func (s *serviceGenerator) generateTestMethods(f *protogen.GeneratedFile) {
 		resourceFx := resourceTestSuiteConfigName(s.service.Desc, resource)
 		f.P("func (fx ", serviceFx, ") Test", resourceType(resource), "(ctx ", context, ", options ", resourceFx, ") {")
 		f.P("fx.T.Run(", strconv.Quote(resourceType(resource)), ", func(t *", testingT, ") {")
-		f.P("options.ctx = ctx")
+		f.P("options.Context = func() ", context, " { return ctx }")
 		f.P("options.service = fx.Server")
 		f.P("options.test(t)")
 		f.P("})")

--- a/internal/plugin/service.go
+++ b/internal/plugin/service.go
@@ -60,13 +60,17 @@ func (s *serviceGenerator) generateTestMethods(f *protogen.GeneratedFile) {
 		GoName:       "T",
 		GoImportPath: "testing",
 	})
+	service := f.QualifiedGoIdent(protogen.GoIdent{
+		GoName:       s.service.GoName + "Server",
+		GoImportPath: s.service.Methods[0].Input.GoIdent.GoImportPath,
+	})
 	serviceFx := serviceTestSuiteName(s.service.Desc)
 	for _, resource := range s.resources {
 		resourceFx := resourceTestSuiteConfigName(s.service.Desc, resource)
 		f.P("func (fx ", serviceFx, ") Test", resourceType(resource), "(ctx ", context, ", options ", resourceFx, ") {")
 		f.P("fx.T.Run(", strconv.Quote(resourceType(resource)), ", func(t *", testingT, ") {")
 		f.P("options.Context = func() ", context, " { return ctx }")
-		f.P("options.service = fx.Server")
+		f.P("options.Service = func() ", service, " { return fx.Server", "}")
 		f.P("options.test(t)")
 		f.P("})")
 		f.P("}")

--- a/internal/util/method.go
+++ b/internal/util/method.go
@@ -25,7 +25,7 @@ func (m MethodCreate) Generate(f *protogen.GeneratedFile, response, err, assign 
 		f.P("}")
 	}
 
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.ctx, &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -59,7 +59,7 @@ type MethodGet struct {
 }
 
 func (m MethodGet) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.ctx, &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
 	f.P("Name: ", m.Name, ",")
 	f.P("})")
 }
@@ -73,7 +73,7 @@ type MethodBatchGet struct {
 }
 
 func (m MethodBatchGet) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.ctx, &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -111,7 +111,7 @@ func (m MethodUpdate) Generate(f *protogen.GeneratedFile, response, err, assign 
 		}
 		f.P("msg.Name = ", m.Name)
 	}
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.ctx, &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
 	if m.Msg != "" {
 		f.P(upper, ":", m.Msg, ",")
 	} else {
@@ -154,7 +154,7 @@ type MethodList struct {
 }
 
 func (m MethodList) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.ctx, &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -177,7 +177,7 @@ type MethodSearch struct {
 }
 
 func (m MethodSearch) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.ctx, &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -200,7 +200,7 @@ type MethodDelete struct {
 }
 
 func (m MethodDelete) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.ctx, &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
 	if m.Name != "" {
 		f.P("Name: ", m.Name, ",")
 	} else {

--- a/internal/util/method.go
+++ b/internal/util/method.go
@@ -25,7 +25,7 @@ func (m MethodCreate) Generate(f *protogen.GeneratedFile, response, err, assign 
 		f.P("}")
 	}
 
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -59,7 +59,7 @@ type MethodGet struct {
 }
 
 func (m MethodGet) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
 	f.P("Name: ", m.Name, ",")
 	f.P("})")
 }
@@ -73,7 +73,7 @@ type MethodBatchGet struct {
 }
 
 func (m MethodBatchGet) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -111,7 +111,7 @@ func (m MethodUpdate) Generate(f *protogen.GeneratedFile, response, err, assign 
 		}
 		f.P("msg.Name = ", m.Name)
 	}
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
 	if m.Msg != "" {
 		f.P(upper, ":", m.Msg, ",")
 	} else {
@@ -154,7 +154,7 @@ type MethodList struct {
 }
 
 func (m MethodList) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -177,7 +177,7 @@ type MethodSearch struct {
 }
 
 func (m MethodSearch) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -200,7 +200,7 @@ type MethodDelete struct {
 }
 
 func (m MethodDelete) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.service.", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{")
+	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
 	if m.Name != "" {
 		f.P("Name: ", m.Name, ",")
 	} else {

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -16,6 +16,53 @@ import (
 	time "time"
 )
 
+// FreightServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type FreightServiceTestSuiteConfigProvider interface {
+	// FreightServiceShipperTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	ShipperTestSuiteConfig(t *testing.T) *FreightServiceShipperTestSuiteConfig
+	// FreightServiceSiteTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	SiteTestSuiteConfig(t *testing.T) *FreightServiceSiteTestSuiteConfig
+}
+
+// TestFreightService is the main entrypoint for starting the AIP tests.
+func TestFreightService(t *testing.T, s FreightServiceTestSuiteConfigProvider) {
+	testFreightServiceShipperTestSuiteConfig(t, s)
+	testFreightServiceSiteTestSuiteConfig(t, s)
+}
+
+func testFreightServiceShipperTestSuiteConfig(t *testing.T, s FreightServiceTestSuiteConfigProvider) {
+	t.Run("Shipper", func(t *testing.T) {
+		config := s.ShipperTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method ShipperTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FreightServiceShipperTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testFreightServiceSiteTestSuiteConfig(t *testing.T, s FreightServiceTestSuiteConfigProvider) {
+	t.Run("Site", func(t *testing.T) {
+		config := s.SiteTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method SiteTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FreightServiceSiteTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type FreightServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/dataset_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/dataset_service_aiptest.pb.go
@@ -15,6 +15,129 @@ import (
 	testing "testing"
 )
 
+// DatasetServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type DatasetServiceTestSuiteConfigProvider interface {
+	// DatasetServiceAnnotationTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	AnnotationTestSuiteConfig(t *testing.T) *DatasetServiceAnnotationTestSuiteConfig
+	// DatasetServiceAnnotationSpecTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	AnnotationSpecTestSuiteConfig(t *testing.T) *DatasetServiceAnnotationSpecTestSuiteConfig
+	// DatasetServiceDataItemTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	DataItemTestSuiteConfig(t *testing.T) *DatasetServiceDataItemTestSuiteConfig
+	// DatasetServiceDatasetTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	DatasetTestSuiteConfig(t *testing.T) *DatasetServiceDatasetTestSuiteConfig
+	// DatasetServiceDatasetVersionTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	DatasetVersionTestSuiteConfig(t *testing.T) *DatasetServiceDatasetVersionTestSuiteConfig
+	// DatasetServiceSavedQueryTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	SavedQueryTestSuiteConfig(t *testing.T) *DatasetServiceSavedQueryTestSuiteConfig
+}
+
+// TestDatasetService is the main entrypoint for starting the AIP tests.
+func TestDatasetService(t *testing.T, s DatasetServiceTestSuiteConfigProvider) {
+	testDatasetServiceAnnotationTestSuiteConfig(t, s)
+	testDatasetServiceAnnotationSpecTestSuiteConfig(t, s)
+	testDatasetServiceDataItemTestSuiteConfig(t, s)
+	testDatasetServiceDatasetTestSuiteConfig(t, s)
+	testDatasetServiceDatasetVersionTestSuiteConfig(t, s)
+	testDatasetServiceSavedQueryTestSuiteConfig(t, s)
+}
+
+func testDatasetServiceAnnotationTestSuiteConfig(t *testing.T, s DatasetServiceTestSuiteConfigProvider) {
+	t.Run("Annotation", func(t *testing.T) {
+		config := s.AnnotationTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method AnnotationTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DatasetServiceAnnotationTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testDatasetServiceAnnotationSpecTestSuiteConfig(t *testing.T, s DatasetServiceTestSuiteConfigProvider) {
+	t.Run("AnnotationSpec", func(t *testing.T) {
+		config := s.AnnotationSpecTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method AnnotationSpecTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DatasetServiceAnnotationSpecTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testDatasetServiceDataItemTestSuiteConfig(t *testing.T, s DatasetServiceTestSuiteConfigProvider) {
+	t.Run("DataItem", func(t *testing.T) {
+		config := s.DataItemTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method DataItemTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DatasetServiceDataItemTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testDatasetServiceDatasetTestSuiteConfig(t *testing.T, s DatasetServiceTestSuiteConfigProvider) {
+	t.Run("Dataset", func(t *testing.T) {
+		config := s.DatasetTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method DatasetTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DatasetServiceDatasetTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testDatasetServiceDatasetVersionTestSuiteConfig(t *testing.T, s DatasetServiceTestSuiteConfigProvider) {
+	t.Run("DatasetVersion", func(t *testing.T) {
+		config := s.DatasetVersionTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method DatasetVersionTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DatasetServiceDatasetVersionTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testDatasetServiceSavedQueryTestSuiteConfig(t *testing.T, s DatasetServiceTestSuiteConfigProvider) {
+	t.Run("SavedQuery", func(t *testing.T) {
+		config := s.SavedQueryTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method SavedQueryTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DatasetServiceSavedQueryTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type DatasetServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/deployment_resource_pool_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/deployment_resource_pool_service_aiptest.pb.go
@@ -13,6 +13,34 @@ import (
 	testing "testing"
 )
 
+// DeploymentResourcePoolServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type DeploymentResourcePoolServiceTestSuiteConfigProvider interface {
+	// DeploymentResourcePoolServiceDeploymentResourcePoolTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	DeploymentResourcePoolTestSuiteConfig(t *testing.T) *DeploymentResourcePoolServiceDeploymentResourcePoolTestSuiteConfig
+}
+
+// TestDeploymentResourcePoolService is the main entrypoint for starting the AIP tests.
+func TestDeploymentResourcePoolService(t *testing.T, s DeploymentResourcePoolServiceTestSuiteConfigProvider) {
+	testDeploymentResourcePoolServiceDeploymentResourcePoolTestSuiteConfig(t, s)
+}
+
+func testDeploymentResourcePoolServiceDeploymentResourcePoolTestSuiteConfig(t *testing.T, s DeploymentResourcePoolServiceTestSuiteConfigProvider) {
+	t.Run("DeploymentResourcePool", func(t *testing.T) {
+		config := s.DeploymentResourcePoolTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method DeploymentResourcePoolTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DeploymentResourcePoolServiceDeploymentResourcePoolTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type DeploymentResourcePoolServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/endpoint_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/endpoint_service_aiptest.pb.go
@@ -15,6 +15,34 @@ import (
 	testing "testing"
 )
 
+// EndpointServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type EndpointServiceTestSuiteConfigProvider interface {
+	// EndpointServiceEndpointTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	EndpointTestSuiteConfig(t *testing.T) *EndpointServiceEndpointTestSuiteConfig
+}
+
+// TestEndpointService is the main entrypoint for starting the AIP tests.
+func TestEndpointService(t *testing.T, s EndpointServiceTestSuiteConfigProvider) {
+	testEndpointServiceEndpointTestSuiteConfig(t, s)
+}
+
+func testEndpointServiceEndpointTestSuiteConfig(t *testing.T, s EndpointServiceTestSuiteConfigProvider) {
+	t.Run("Endpoint", func(t *testing.T) {
+		config := s.EndpointTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method EndpointTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method EndpointServiceEndpointTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type EndpointServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/endpoint_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/endpoint_service_aiptest.pb.go
@@ -23,17 +23,19 @@ type EndpointServiceTestSuite struct {
 
 func (fx EndpointServiceTestSuite) TestEndpoint(ctx context.Context, options EndpointServiceEndpointTestSuiteConfig) {
 	fx.T.Run("Endpoint", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
 }
 
 type EndpointServiceEndpointTestSuiteConfig struct {
-	ctx        context.Context
 	service    EndpointServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -65,7 +67,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateEndpoint(fx.ctx, &CreateEndpointRequest{
+		_, err := fx.service.CreateEndpoint(fx.Context(), &CreateEndpointRequest{
 			Parent:   "",
 			Endpoint: fx.Create(fx.nextParent(t, false)),
 		})
@@ -75,7 +77,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateEndpoint(fx.ctx, &CreateEndpointRequest{
+		_, err := fx.service.CreateEndpoint(fx.Context(), &CreateEndpointRequest{
 			Parent:   "invalid resource name",
 			Endpoint: fx.Create(fx.nextParent(t, false)),
 		})
@@ -96,7 +98,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateEndpoint(fx.ctx, &CreateEndpointRequest{
+			_, err := fx.service.CreateEndpoint(fx.Context(), &CreateEndpointRequest{
 				Parent:   parent,
 				Endpoint: msg,
 			})
@@ -112,7 +114,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateEndpoint(fx.ctx, &CreateEndpointRequest{
+			_, err := fx.service.CreateEndpoint(fx.Context(), &CreateEndpointRequest{
 				Parent:   parent,
 				Endpoint: msg,
 			})
@@ -128,7 +130,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateEndpoint(fx.ctx, &CreateEndpointRequest{
+			_, err := fx.service.CreateEndpoint(fx.Context(), &CreateEndpointRequest{
 				Parent:   parent,
 				Endpoint: msg,
 			})
@@ -149,7 +151,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Network = "invalid resource name"
-			_, err := fx.service.CreateEndpoint(fx.ctx, &CreateEndpointRequest{
+			_, err := fx.service.CreateEndpoint(fx.Context(), &CreateEndpointRequest{
 				Parent:   parent,
 				Endpoint: msg,
 			})
@@ -164,7 +166,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetEndpoint(fx.ctx, &GetEndpointRequest{
+		_, err := fx.service.GetEndpoint(fx.Context(), &GetEndpointRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -173,7 +175,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetEndpoint(fx.ctx, &GetEndpointRequest{
+		_, err := fx.service.GetEndpoint(fx.Context(), &GetEndpointRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -184,7 +186,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetEndpoint(fx.ctx, &GetEndpointRequest{
+		msg, err := fx.service.GetEndpoint(fx.Context(), &GetEndpointRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -196,7 +198,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetEndpoint(fx.ctx, &GetEndpointRequest{
+		_, err := fx.service.GetEndpoint(fx.Context(), &GetEndpointRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -205,7 +207,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetEndpoint(fx.ctx, &GetEndpointRequest{
+		_, err := fx.service.GetEndpoint(fx.Context(), &GetEndpointRequest{
 			Name: "projects/-/locations/-/endpoints/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -221,7 +223,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateEndpoint(fx.ctx, &UpdateEndpointRequest{
+		_, err := fx.service.UpdateEndpoint(fx.Context(), &UpdateEndpointRequest{
 			Endpoint: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -233,7 +235,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateEndpoint(fx.ctx, &UpdateEndpointRequest{
+		_, err := fx.service.UpdateEndpoint(fx.Context(), &UpdateEndpointRequest{
 			Endpoint: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -244,11 +246,11 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		updated, err := fx.service.UpdateEndpoint(fx.ctx, &UpdateEndpointRequest{
+		updated, err := fx.service.UpdateEndpoint(fx.Context(), &UpdateEndpointRequest{
 			Endpoint: created,
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetEndpoint(fx.ctx, &GetEndpointRequest{
+		persisted, err := fx.service.GetEndpoint(fx.Context(), &GetEndpointRequest{
 			Name: updated.Name,
 		})
 		assert.NilError(t, err)
@@ -261,7 +263,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
 		originalCreateTime := created.CreateTime
-		updated, err := fx.service.UpdateEndpoint(fx.ctx, &UpdateEndpointRequest{
+		updated, err := fx.service.UpdateEndpoint(fx.Context(), &UpdateEndpointRequest{
 			Endpoint: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -280,7 +282,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateEndpoint(fx.ctx, &UpdateEndpointRequest{
+		_, err := fx.service.UpdateEndpoint(fx.Context(), &UpdateEndpointRequest{
 			Endpoint: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -289,7 +291,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateEndpoint(fx.ctx, &UpdateEndpointRequest{
+		_, err := fx.service.UpdateEndpoint(fx.Context(), &UpdateEndpointRequest{
 			Endpoint: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -313,7 +315,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateEndpoint(fx.ctx, &UpdateEndpointRequest{
+			_, err := fx.service.UpdateEndpoint(fx.Context(), &UpdateEndpointRequest{
 				Endpoint: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -332,7 +334,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateEndpoint(fx.ctx, &UpdateEndpointRequest{
+			_, err := fx.service.UpdateEndpoint(fx.Context(), &UpdateEndpointRequest{
 				Endpoint: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -351,7 +353,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateEndpoint(fx.ctx, &UpdateEndpointRequest{
+			_, err := fx.service.UpdateEndpoint(fx.Context(), &UpdateEndpointRequest{
 				Endpoint: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -370,7 +372,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListEndpoints(fx.ctx, &ListEndpointsRequest{
+		_, err := fx.service.ListEndpoints(fx.Context(), &ListEndpointsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -380,7 +382,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListEndpoints(fx.ctx, &ListEndpointsRequest{
+		_, err := fx.service.ListEndpoints(fx.Context(), &ListEndpointsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -391,7 +393,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListEndpoints(fx.ctx, &ListEndpointsRequest{
+		_, err := fx.service.ListEndpoints(fx.Context(), &ListEndpointsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -409,7 +411,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListEndpoints(fx.ctx, &ListEndpointsRequest{
+		response, err := fx.service.ListEndpoints(fx.Context(), &ListEndpointsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -428,7 +430,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListEndpoints(fx.ctx, &ListEndpointsRequest{
+		response, err := fx.service.ListEndpoints(fx.Context(), &ListEndpointsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -439,7 +441,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListEndpoints(fx.ctx, &ListEndpointsRequest{
+		response, err := fx.service.ListEndpoints(fx.Context(), &ListEndpointsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -453,7 +455,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*Endpoint, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListEndpoints(fx.ctx, &ListEndpointsRequest{
+			response, err := fx.service.ListEndpoints(fx.Context(), &ListEndpointsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -482,12 +484,12 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteEndpoint(fx.ctx, &DeleteEndpointRequest{
+			_, err := fx.service.DeleteEndpoint(fx.Context(), &DeleteEndpointRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListEndpoints(fx.ctx, &ListEndpointsRequest{
+		response, err := fx.service.ListEndpoints(fx.Context(), &ListEndpointsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -510,7 +512,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteEndpoint(fx.ctx, &DeleteEndpointRequest{
+		_, err := fx.service.DeleteEndpoint(fx.Context(), &DeleteEndpointRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -519,7 +521,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteEndpoint(fx.ctx, &DeleteEndpointRequest{
+		_, err := fx.service.DeleteEndpoint(fx.Context(), &DeleteEndpointRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -530,7 +532,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteEndpoint(fx.ctx, &DeleteEndpointRequest{
+		_, err := fx.service.DeleteEndpoint(fx.Context(), &DeleteEndpointRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -541,7 +543,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteEndpoint(fx.ctx, &DeleteEndpointRequest{
+		_, err := fx.service.DeleteEndpoint(fx.Context(), &DeleteEndpointRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -552,12 +554,12 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteEndpoint(fx.ctx, &DeleteEndpointRequest{
+		deleted, err := fx.service.DeleteEndpoint(fx.Context(), &DeleteEndpointRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteEndpoint(fx.ctx, &DeleteEndpointRequest{
+		_, err = fx.service.DeleteEndpoint(fx.Context(), &DeleteEndpointRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -566,7 +568,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteEndpoint(fx.ctx, &DeleteEndpointRequest{
+		_, err := fx.service.DeleteEndpoint(fx.Context(), &DeleteEndpointRequest{
 			Name: "projects/-/locations/-/endpoints/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_online_store_admin_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_online_store_admin_service_aiptest.pb.go
@@ -24,7 +24,7 @@ type FeatureOnlineStoreAdminServiceTestSuite struct {
 func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureOnlineStore(ctx context.Context, options FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) {
 	fx.T.Run("FeatureOnlineStore", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() FeatureOnlineStoreAdminServiceServer { return fx.Server }
 		options.test(t)
 	})
 }
@@ -32,7 +32,7 @@ func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureOnlineStore(ctx con
 func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureView(ctx context.Context, options FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) {
 	fx.T.Run("FeatureView", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() FeatureOnlineStoreAdminServiceServer { return fx.Server }
 		options.test(t)
 	})
 }
@@ -40,15 +40,17 @@ func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureView(ctx context.Co
 func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureViewSync(ctx context.Context, options FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) {
 	fx.T.Run("FeatureViewSync", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() FeatureOnlineStoreAdminServiceServer { return fx.Server }
 		options.test(t)
 	})
 }
 
 type FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig struct {
-	service    FeatureOnlineStoreAdminServiceServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() FeatureOnlineStoreAdminServiceServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -83,7 +85,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
+		_, err := fx.Service().CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 			Parent:             "",
 			FeatureOnlineStore: fx.Create(fx.nextParent(t, false)),
 		})
@@ -93,7 +95,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
+		_, err := fx.Service().CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 			Parent:             "invalid resource name",
 			FeatureOnlineStore: fx.Create(fx.nextParent(t, false)),
 		})
@@ -114,7 +116,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("auto_scaling")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
+			_, err := fx.Service().CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 				Parent:             parent,
 				FeatureOnlineStore: msg,
 			})
@@ -130,7 +132,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("min_node_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
+			_, err := fx.Service().CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 				Parent:             parent,
 				FeatureOnlineStore: msg,
 			})
@@ -146,7 +148,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_node_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
+			_, err := fx.Service().CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 				Parent:             parent,
 				FeatureOnlineStore: msg,
 			})
@@ -161,7 +163,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
+		_, err := fx.Service().GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -170,7 +172,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
+		_, err := fx.Service().GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -181,7 +183,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
+		msg, err := fx.Service().GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -193,7 +195,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
+		_, err := fx.Service().GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -202,7 +204,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
+		_, err := fx.Service().GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -218,7 +220,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
+		_, err := fx.Service().UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 			FeatureOnlineStore: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -230,7 +232,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
+		_, err := fx.Service().UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 			FeatureOnlineStore: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -243,7 +245,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
+		_, err := fx.Service().UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 			FeatureOnlineStore: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -252,7 +254,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
+		_, err := fx.Service().UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 			FeatureOnlineStore: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -276,7 +278,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("auto_scaling")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
+			_, err := fx.Service().UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 				FeatureOnlineStore: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -295,7 +297,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("min_node_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
+			_, err := fx.Service().UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 				FeatureOnlineStore: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -314,7 +316,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_node_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
+			_, err := fx.Service().UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 				FeatureOnlineStore: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -333,7 +335,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
+		_, err := fx.Service().ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -343,7 +345,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
+		_, err := fx.Service().ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -354,7 +356,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
+		_, err := fx.Service().ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -372,7 +374,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
+		response, err := fx.Service().ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -391,7 +393,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
+		response, err := fx.Service().ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -402,7 +404,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
+		response, err := fx.Service().ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -416,7 +418,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 		msgs := make([]*FeatureOnlineStore, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
+			response, err := fx.Service().ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -445,12 +447,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
+			_, err := fx.Service().DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
+		response, err := fx.Service().ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -473,7 +475,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.Service().DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -482,7 +484,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.Service().DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -493,7 +495,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.Service().DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -504,7 +506,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.Service().DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -515,12 +517,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
+		deleted, err := fx.Service().DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
+		_, err = fx.Service().DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -529,7 +531,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.Service().DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -570,9 +572,11 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) creat
 }
 
 type FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig struct {
-	service    FeatureOnlineStoreAdminServiceServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() FeatureOnlineStoreAdminServiceServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -607,7 +611,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
+		_, err := fx.Service().CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 			Parent:      "",
 			FeatureView: fx.Create(fx.nextParent(t, false)),
 		})
@@ -617,7 +621,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
+		_, err := fx.Service().CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 			Parent:      "invalid resource name",
 			FeatureView: fx.Create(fx.nextParent(t, false)),
 		})
@@ -638,7 +642,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
+			_, err := fx.Service().CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 				Parent:      parent,
 				FeatureView: msg,
 			})
@@ -654,7 +658,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("entity_id_columns")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
+			_, err := fx.Service().CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 				Parent:      parent,
 				FeatureView: msg,
 			})
@@ -670,7 +674,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("feature_groups")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
+			_, err := fx.Service().CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 				Parent:      parent,
 				FeatureView: msg,
 			})
@@ -685,7 +689,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
+		_, err := fx.Service().GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -694,7 +698,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
+		_, err := fx.Service().GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -705,7 +709,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
+		msg, err := fx.Service().GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -717,7 +721,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
+		_, err := fx.Service().GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -726,7 +730,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
+		_, err := fx.Service().GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-/featureViews/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -742,7 +746,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
+		_, err := fx.Service().UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 			FeatureView: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -754,7 +758,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
+		_, err := fx.Service().UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 			FeatureView: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -767,7 +771,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
+		_, err := fx.Service().UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 			FeatureView: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -776,7 +780,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
+		_, err := fx.Service().UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 			FeatureView: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -800,7 +804,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
+			_, err := fx.Service().UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 				FeatureView: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -819,7 +823,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("entity_id_columns")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
+			_, err := fx.Service().UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 				FeatureView: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -838,7 +842,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("feature_groups")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
+			_, err := fx.Service().UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 				FeatureView: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -857,7 +861,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
+		_, err := fx.Service().ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -867,7 +871,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
+		_, err := fx.Service().ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -878,7 +882,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
+		_, err := fx.Service().ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -896,7 +900,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
+		response, err := fx.Service().ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -915,7 +919,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
+		response, err := fx.Service().ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -926,7 +930,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
+		response, err := fx.Service().ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -940,7 +944,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 		msgs := make([]*FeatureView, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
+			response, err := fx.Service().ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -969,12 +973,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
+			_, err := fx.Service().DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
+		response, err := fx.Service().ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -997,7 +1001,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
+		_, err := fx.Service().DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1006,7 +1010,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
+		_, err := fx.Service().DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1017,7 +1021,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
+		_, err := fx.Service().DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1028,7 +1032,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
+		_, err := fx.Service().DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1039,12 +1043,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
+		deleted, err := fx.Service().DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
+		_, err = fx.Service().DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1053,7 +1057,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
+		_, err := fx.Service().DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-/featureViews/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1094,9 +1098,11 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) create(t *te
 }
 
 type FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig struct {
-	service    FeatureOnlineStoreAdminServiceServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() FeatureOnlineStoreAdminServiceServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -1128,7 +1134,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
+		_, err := fx.Service().GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1137,7 +1143,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
+		_, err := fx.Service().GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1148,7 +1154,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
+		msg, err := fx.Service().GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1160,7 +1166,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
+		_, err := fx.Service().GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1169,7 +1175,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
+		_, err := fx.Service().GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-/featureViews/-/featureViewSyncs/feature_view_sync",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1182,7 +1188,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
+		_, err := fx.Service().ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1192,7 +1198,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
+		_, err := fx.Service().ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -1203,7 +1209,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
+		_, err := fx.Service().ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -1221,7 +1227,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
+		response, err := fx.Service().ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -1240,7 +1246,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
+		response, err := fx.Service().ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -1251,7 +1257,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
+		response, err := fx.Service().ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -1265,7 +1271,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 		msgs := make([]*FeatureViewSync, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
+			response, err := fx.Service().ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_online_store_admin_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_online_store_admin_service_aiptest.pb.go
@@ -23,7 +23,7 @@ type FeatureOnlineStoreAdminServiceTestSuite struct {
 
 func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureOnlineStore(ctx context.Context, options FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) {
 	fx.T.Run("FeatureOnlineStore", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -31,7 +31,7 @@ func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureOnlineStore(ctx con
 
 func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureView(ctx context.Context, options FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) {
 	fx.T.Run("FeatureView", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -39,17 +39,19 @@ func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureView(ctx context.Co
 
 func (fx FeatureOnlineStoreAdminServiceTestSuite) TestFeatureViewSync(ctx context.Context, options FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) {
 	fx.T.Run("FeatureViewSync", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
 }
 
 type FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig struct {
-	ctx        context.Context
 	service    FeatureOnlineStoreAdminServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -81,7 +83,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateFeatureOnlineStore(fx.ctx, &CreateFeatureOnlineStoreRequest{
+		_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 			Parent:             "",
 			FeatureOnlineStore: fx.Create(fx.nextParent(t, false)),
 		})
@@ -91,7 +93,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateFeatureOnlineStore(fx.ctx, &CreateFeatureOnlineStoreRequest{
+		_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 			Parent:             "invalid resource name",
 			FeatureOnlineStore: fx.Create(fx.nextParent(t, false)),
 		})
@@ -112,7 +114,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("auto_scaling")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureOnlineStore(fx.ctx, &CreateFeatureOnlineStoreRequest{
+			_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 				Parent:             parent,
 				FeatureOnlineStore: msg,
 			})
@@ -128,7 +130,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("min_node_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureOnlineStore(fx.ctx, &CreateFeatureOnlineStoreRequest{
+			_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 				Parent:             parent,
 				FeatureOnlineStore: msg,
 			})
@@ -144,7 +146,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testC
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_node_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureOnlineStore(fx.ctx, &CreateFeatureOnlineStoreRequest{
+			_, err := fx.service.CreateFeatureOnlineStore(fx.Context(), &CreateFeatureOnlineStoreRequest{
 				Parent:             parent,
 				FeatureOnlineStore: msg,
 			})
@@ -159,7 +161,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureOnlineStore(fx.ctx, &GetFeatureOnlineStoreRequest{
+		_, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -168,7 +170,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureOnlineStore(fx.ctx, &GetFeatureOnlineStoreRequest{
+		_, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -179,7 +181,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetFeatureOnlineStore(fx.ctx, &GetFeatureOnlineStoreRequest{
+		msg, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -191,7 +193,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetFeatureOnlineStore(fx.ctx, &GetFeatureOnlineStoreRequest{
+		_, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -200,7 +202,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testG
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureOnlineStore(fx.ctx, &GetFeatureOnlineStoreRequest{
+		_, err := fx.service.GetFeatureOnlineStore(fx.Context(), &GetFeatureOnlineStoreRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -216,7 +218,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateFeatureOnlineStore(fx.ctx, &UpdateFeatureOnlineStoreRequest{
+		_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 			FeatureOnlineStore: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -228,7 +230,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateFeatureOnlineStore(fx.ctx, &UpdateFeatureOnlineStoreRequest{
+		_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 			FeatureOnlineStore: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -241,7 +243,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateFeatureOnlineStore(fx.ctx, &UpdateFeatureOnlineStoreRequest{
+		_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 			FeatureOnlineStore: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -250,7 +252,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateFeatureOnlineStore(fx.ctx, &UpdateFeatureOnlineStoreRequest{
+		_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 			FeatureOnlineStore: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -274,7 +276,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("auto_scaling")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureOnlineStore(fx.ctx, &UpdateFeatureOnlineStoreRequest{
+			_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 				FeatureOnlineStore: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -293,7 +295,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("min_node_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureOnlineStore(fx.ctx, &UpdateFeatureOnlineStoreRequest{
+			_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 				FeatureOnlineStore: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -312,7 +314,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testU
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_node_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureOnlineStore(fx.ctx, &UpdateFeatureOnlineStoreRequest{
+			_, err := fx.service.UpdateFeatureOnlineStore(fx.Context(), &UpdateFeatureOnlineStoreRequest{
 				FeatureOnlineStore: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -331,7 +333,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListFeatureOnlineStores(fx.ctx, &ListFeatureOnlineStoresRequest{
+		_, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -341,7 +343,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureOnlineStores(fx.ctx, &ListFeatureOnlineStoresRequest{
+		_, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -352,7 +354,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureOnlineStores(fx.ctx, &ListFeatureOnlineStoresRequest{
+		_, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -370,7 +372,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureOnlineStores(fx.ctx, &ListFeatureOnlineStoresRequest{
+		response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -389,7 +391,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureOnlineStores(fx.ctx, &ListFeatureOnlineStoresRequest{
+		response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -400,7 +402,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureOnlineStores(fx.ctx, &ListFeatureOnlineStoresRequest{
+		response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -414,7 +416,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 		msgs := make([]*FeatureOnlineStore, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListFeatureOnlineStores(fx.ctx, &ListFeatureOnlineStoresRequest{
+			response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -443,12 +445,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteFeatureOnlineStore(fx.ctx, &DeleteFeatureOnlineStoreRequest{
+			_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListFeatureOnlineStores(fx.ctx, &ListFeatureOnlineStoresRequest{
+		response, err := fx.service.ListFeatureOnlineStores(fx.Context(), &ListFeatureOnlineStoresRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -471,7 +473,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.ctx, &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -480,7 +482,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.ctx, &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -491,7 +493,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.ctx, &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -502,7 +504,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.ctx, &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -513,12 +515,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteFeatureOnlineStore(fx.ctx, &DeleteFeatureOnlineStoreRequest{
+		deleted, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteFeatureOnlineStore(fx.ctx, &DeleteFeatureOnlineStoreRequest{
+		_, err = fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -527,7 +529,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testD
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureOnlineStore(fx.ctx, &DeleteFeatureOnlineStoreRequest{
+		_, err := fx.service.DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -568,10 +570,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) creat
 }
 
 type FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig struct {
-	ctx        context.Context
 	service    FeatureOnlineStoreAdminServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -603,7 +607,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateFeatureView(fx.ctx, &CreateFeatureViewRequest{
+		_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 			Parent:      "",
 			FeatureView: fx.Create(fx.nextParent(t, false)),
 		})
@@ -613,7 +617,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateFeatureView(fx.ctx, &CreateFeatureViewRequest{
+		_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 			Parent:      "invalid resource name",
 			FeatureView: fx.Create(fx.nextParent(t, false)),
 		})
@@ -634,7 +638,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureView(fx.ctx, &CreateFeatureViewRequest{
+			_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 				Parent:      parent,
 				FeatureView: msg,
 			})
@@ -650,7 +654,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("entity_id_columns")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureView(fx.ctx, &CreateFeatureViewRequest{
+			_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 				Parent:      parent,
 				FeatureView: msg,
 			})
@@ -666,7 +670,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testCreate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("feature_groups")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateFeatureView(fx.ctx, &CreateFeatureViewRequest{
+			_, err := fx.service.CreateFeatureView(fx.Context(), &CreateFeatureViewRequest{
 				Parent:      parent,
 				FeatureView: msg,
 			})
@@ -681,7 +685,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureView(fx.ctx, &GetFeatureViewRequest{
+		_, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -690,7 +694,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureView(fx.ctx, &GetFeatureViewRequest{
+		_, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -701,7 +705,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetFeatureView(fx.ctx, &GetFeatureViewRequest{
+		msg, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -713,7 +717,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetFeatureView(fx.ctx, &GetFeatureViewRequest{
+		_, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -722,7 +726,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testGet(t *t
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureView(fx.ctx, &GetFeatureViewRequest{
+		_, err := fx.service.GetFeatureView(fx.Context(), &GetFeatureViewRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-/featureViews/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -738,7 +742,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateFeatureView(fx.ctx, &UpdateFeatureViewRequest{
+		_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 			FeatureView: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -750,7 +754,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateFeatureView(fx.ctx, &UpdateFeatureViewRequest{
+		_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 			FeatureView: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -763,7 +767,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateFeatureView(fx.ctx, &UpdateFeatureViewRequest{
+		_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 			FeatureView: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -772,7 +776,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateFeatureView(fx.ctx, &UpdateFeatureViewRequest{
+		_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 			FeatureView: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -796,7 +800,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureView(fx.ctx, &UpdateFeatureViewRequest{
+			_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 				FeatureView: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -815,7 +819,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("entity_id_columns")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureView(fx.ctx, &UpdateFeatureViewRequest{
+			_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 				FeatureView: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -834,7 +838,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testUpdate(t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("feature_groups")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateFeatureView(fx.ctx, &UpdateFeatureViewRequest{
+			_, err := fx.service.UpdateFeatureView(fx.Context(), &UpdateFeatureViewRequest{
 				FeatureView: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -853,7 +857,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListFeatureViews(fx.ctx, &ListFeatureViewsRequest{
+		_, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -863,7 +867,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureViews(fx.ctx, &ListFeatureViewsRequest{
+		_, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -874,7 +878,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureViews(fx.ctx, &ListFeatureViewsRequest{
+		_, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -892,7 +896,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViews(fx.ctx, &ListFeatureViewsRequest{
+		response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -911,7 +915,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViews(fx.ctx, &ListFeatureViewsRequest{
+		response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -922,7 +926,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViews(fx.ctx, &ListFeatureViewsRequest{
+		response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -936,7 +940,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 		msgs := make([]*FeatureView, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListFeatureViews(fx.ctx, &ListFeatureViewsRequest{
+			response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -965,12 +969,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteFeatureView(fx.ctx, &DeleteFeatureViewRequest{
+			_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListFeatureViews(fx.ctx, &ListFeatureViewsRequest{
+		response, err := fx.service.ListFeatureViews(fx.Context(), &ListFeatureViewsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -993,7 +997,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureView(fx.ctx, &DeleteFeatureViewRequest{
+		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1002,7 +1006,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureView(fx.ctx, &DeleteFeatureViewRequest{
+		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1013,7 +1017,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteFeatureView(fx.ctx, &DeleteFeatureViewRequest{
+		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1024,7 +1028,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteFeatureView(fx.ctx, &DeleteFeatureViewRequest{
+		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1035,12 +1039,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteFeatureView(fx.ctx, &DeleteFeatureViewRequest{
+		deleted, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteFeatureView(fx.ctx, &DeleteFeatureViewRequest{
+		_, err = fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1049,7 +1053,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testDelete(t
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteFeatureView(fx.ctx, &DeleteFeatureViewRequest{
+		_, err := fx.service.DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-/featureViews/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1090,10 +1094,12 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) create(t *te
 }
 
 type FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig struct {
-	ctx        context.Context
 	service    FeatureOnlineStoreAdminServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -1122,7 +1128,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureViewSync(fx.ctx, &GetFeatureViewSyncRequest{
+		_, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1131,7 +1137,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureViewSync(fx.ctx, &GetFeatureViewSyncRequest{
+		_, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1142,7 +1148,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetFeatureViewSync(fx.ctx, &GetFeatureViewSyncRequest{
+		msg, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1154,7 +1160,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetFeatureViewSync(fx.ctx, &GetFeatureViewSyncRequest{
+		_, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1163,7 +1169,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testGet(
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetFeatureViewSync(fx.ctx, &GetFeatureViewSyncRequest{
+		_, err := fx.service.GetFeatureViewSync(fx.Context(), &GetFeatureViewSyncRequest{
 			Name: "projects/-/locations/-/featureOnlineStores/-/featureViews/-/featureViewSyncs/feature_view_sync",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1176,7 +1182,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListFeatureViewSyncs(fx.ctx, &ListFeatureViewSyncsRequest{
+		_, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1186,7 +1192,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureViewSyncs(fx.ctx, &ListFeatureViewSyncsRequest{
+		_, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -1197,7 +1203,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListFeatureViewSyncs(fx.ctx, &ListFeatureViewSyncsRequest{
+		_, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -1215,7 +1221,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViewSyncs(fx.ctx, &ListFeatureViewSyncsRequest{
+		response, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -1234,7 +1240,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViewSyncs(fx.ctx, &ListFeatureViewSyncsRequest{
+		response, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -1245,7 +1251,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListFeatureViewSyncs(fx.ctx, &ListFeatureViewSyncsRequest{
+		response, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -1259,7 +1265,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 		msgs := make([]*FeatureViewSync, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListFeatureViewSyncs(fx.ctx, &ListFeatureViewSyncsRequest{
+			response, err := fx.service.ListFeatureViewSyncs(fx.Context(), &ListFeatureViewSyncsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -1316,7 +1322,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) create(t
 	if fx.CreateResource == nil {
 		t.Skip("Test skipped because CreateResource not specified on FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig")
 	}
-	created, err := fx.CreateResource(fx.ctx, parent)
+	created, err := fx.CreateResource(fx.Context(), parent)
 	assert.NilError(t, err)
 	return created
 }

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_online_store_admin_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_online_store_admin_service_aiptest.pb.go
@@ -15,6 +15,72 @@ import (
 	testing "testing"
 )
 
+// FeatureOnlineStoreAdminServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type FeatureOnlineStoreAdminServiceTestSuiteConfigProvider interface {
+	// FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	FeatureOnlineStoreTestSuiteConfig(t *testing.T) *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig
+	// FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	FeatureViewTestSuiteConfig(t *testing.T) *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig
+	// FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	FeatureViewSyncTestSuiteConfig(t *testing.T) *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig
+}
+
+// TestFeatureOnlineStoreAdminService is the main entrypoint for starting the AIP tests.
+func TestFeatureOnlineStoreAdminService(t *testing.T, s FeatureOnlineStoreAdminServiceTestSuiteConfigProvider) {
+	testFeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig(t, s)
+	testFeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig(t, s)
+	testFeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig(t, s)
+}
+
+func testFeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig(t *testing.T, s FeatureOnlineStoreAdminServiceTestSuiteConfigProvider) {
+	t.Run("FeatureOnlineStore", func(t *testing.T) {
+		config := s.FeatureOnlineStoreTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method FeatureOnlineStoreTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testFeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig(t *testing.T, s FeatureOnlineStoreAdminServiceTestSuiteConfigProvider) {
+	t.Run("FeatureView", func(t *testing.T) {
+		config := s.FeatureViewTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method FeatureViewTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testFeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig(t *testing.T, s FeatureOnlineStoreAdminServiceTestSuiteConfigProvider) {
+	t.Run("FeatureViewSync", func(t *testing.T) {
+		config := s.FeatureViewSyncTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method FeatureViewSyncTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type FeatureOnlineStoreAdminServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_registry_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_registry_service_aiptest.pb.go
@@ -15,6 +15,53 @@ import (
 	testing "testing"
 )
 
+// FeatureRegistryServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type FeatureRegistryServiceTestSuiteConfigProvider interface {
+	// FeatureRegistryServiceFeatureTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	FeatureTestSuiteConfig(t *testing.T) *FeatureRegistryServiceFeatureTestSuiteConfig
+	// FeatureRegistryServiceFeatureGroupTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	FeatureGroupTestSuiteConfig(t *testing.T) *FeatureRegistryServiceFeatureGroupTestSuiteConfig
+}
+
+// TestFeatureRegistryService is the main entrypoint for starting the AIP tests.
+func TestFeatureRegistryService(t *testing.T, s FeatureRegistryServiceTestSuiteConfigProvider) {
+	testFeatureRegistryServiceFeatureTestSuiteConfig(t, s)
+	testFeatureRegistryServiceFeatureGroupTestSuiteConfig(t, s)
+}
+
+func testFeatureRegistryServiceFeatureTestSuiteConfig(t *testing.T, s FeatureRegistryServiceTestSuiteConfigProvider) {
+	t.Run("Feature", func(t *testing.T) {
+		config := s.FeatureTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method FeatureTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FeatureRegistryServiceFeatureTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testFeatureRegistryServiceFeatureGroupTestSuiteConfig(t *testing.T, s FeatureRegistryServiceTestSuiteConfigProvider) {
+	t.Run("FeatureGroup", func(t *testing.T) {
+		config := s.FeatureGroupTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method FeatureGroupTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FeatureRegistryServiceFeatureGroupTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type FeatureRegistryServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/featurestore_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/featurestore_service_aiptest.pb.go
@@ -15,6 +15,72 @@ import (
 	testing "testing"
 )
 
+// FeaturestoreServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type FeaturestoreServiceTestSuiteConfigProvider interface {
+	// FeaturestoreServiceEntityTypeTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	EntityTypeTestSuiteConfig(t *testing.T) *FeaturestoreServiceEntityTypeTestSuiteConfig
+	// FeaturestoreServiceFeatureTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	FeatureTestSuiteConfig(t *testing.T) *FeaturestoreServiceFeatureTestSuiteConfig
+	// FeaturestoreServiceFeaturestoreTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	FeaturestoreTestSuiteConfig(t *testing.T) *FeaturestoreServiceFeaturestoreTestSuiteConfig
+}
+
+// TestFeaturestoreService is the main entrypoint for starting the AIP tests.
+func TestFeaturestoreService(t *testing.T, s FeaturestoreServiceTestSuiteConfigProvider) {
+	testFeaturestoreServiceEntityTypeTestSuiteConfig(t, s)
+	testFeaturestoreServiceFeatureTestSuiteConfig(t, s)
+	testFeaturestoreServiceFeaturestoreTestSuiteConfig(t, s)
+}
+
+func testFeaturestoreServiceEntityTypeTestSuiteConfig(t *testing.T, s FeaturestoreServiceTestSuiteConfigProvider) {
+	t.Run("EntityType", func(t *testing.T) {
+		config := s.EntityTypeTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method EntityTypeTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FeaturestoreServiceEntityTypeTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testFeaturestoreServiceFeatureTestSuiteConfig(t *testing.T, s FeaturestoreServiceTestSuiteConfigProvider) {
+	t.Run("Feature", func(t *testing.T) {
+		config := s.FeatureTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method FeatureTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FeaturestoreServiceFeatureTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testFeaturestoreServiceFeaturestoreTestSuiteConfig(t *testing.T, s FeaturestoreServiceTestSuiteConfigProvider) {
+	t.Run("Featurestore", func(t *testing.T) {
+		config := s.FeaturestoreTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method FeaturestoreTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method FeaturestoreServiceFeaturestoreTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type FeaturestoreServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_endpoint_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_endpoint_service_aiptest.pb.go
@@ -15,6 +15,34 @@ import (
 	testing "testing"
 )
 
+// IndexEndpointServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type IndexEndpointServiceTestSuiteConfigProvider interface {
+	// IndexEndpointServiceIndexEndpointTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	IndexEndpointTestSuiteConfig(t *testing.T) *IndexEndpointServiceIndexEndpointTestSuiteConfig
+}
+
+// TestIndexEndpointService is the main entrypoint for starting the AIP tests.
+func TestIndexEndpointService(t *testing.T, s IndexEndpointServiceTestSuiteConfigProvider) {
+	testIndexEndpointServiceIndexEndpointTestSuiteConfig(t, s)
+}
+
+func testIndexEndpointServiceIndexEndpointTestSuiteConfig(t *testing.T, s IndexEndpointServiceTestSuiteConfigProvider) {
+	t.Run("IndexEndpoint", func(t *testing.T) {
+		config := s.IndexEndpointTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method IndexEndpointTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method IndexEndpointServiceIndexEndpointTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type IndexEndpointServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_service_aiptest.pb.go
@@ -23,17 +23,19 @@ type IndexServiceTestSuite struct {
 
 func (fx IndexServiceTestSuite) TestIndex(ctx context.Context, options IndexServiceIndexTestSuiteConfig) {
 	fx.T.Run("Index", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
 }
 
 type IndexServiceIndexTestSuiteConfig struct {
-	ctx        context.Context
 	service    IndexServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -65,7 +67,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateIndex(fx.ctx, &CreateIndexRequest{
+		_, err := fx.service.CreateIndex(fx.Context(), &CreateIndexRequest{
 			Parent: "",
 			Index:  fx.Create(fx.nextParent(t, false)),
 		})
@@ -75,7 +77,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateIndex(fx.ctx, &CreateIndexRequest{
+		_, err := fx.service.CreateIndex(fx.Context(), &CreateIndexRequest{
 			Parent: "invalid resource name",
 			Index:  fx.Create(fx.nextParent(t, false)),
 		})
@@ -96,7 +98,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateIndex(fx.ctx, &CreateIndexRequest{
+			_, err := fx.service.CreateIndex(fx.Context(), &CreateIndexRequest{
 				Parent: parent,
 				Index:  msg,
 			})
@@ -112,7 +114,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateIndex(fx.ctx, &CreateIndexRequest{
+			_, err := fx.service.CreateIndex(fx.Context(), &CreateIndexRequest{
 				Parent: parent,
 				Index:  msg,
 			})
@@ -127,7 +129,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetIndex(fx.ctx, &GetIndexRequest{
+		_, err := fx.service.GetIndex(fx.Context(), &GetIndexRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -136,7 +138,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetIndex(fx.ctx, &GetIndexRequest{
+		_, err := fx.service.GetIndex(fx.Context(), &GetIndexRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -147,7 +149,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetIndex(fx.ctx, &GetIndexRequest{
+		msg, err := fx.service.GetIndex(fx.Context(), &GetIndexRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -159,7 +161,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetIndex(fx.ctx, &GetIndexRequest{
+		_, err := fx.service.GetIndex(fx.Context(), &GetIndexRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -168,7 +170,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetIndex(fx.ctx, &GetIndexRequest{
+		_, err := fx.service.GetIndex(fx.Context(), &GetIndexRequest{
 			Name: "projects/-/locations/-/indexes/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -184,7 +186,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateIndex(fx.ctx, &UpdateIndexRequest{
+		_, err := fx.service.UpdateIndex(fx.Context(), &UpdateIndexRequest{
 			Index: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -196,7 +198,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateIndex(fx.ctx, &UpdateIndexRequest{
+		_, err := fx.service.UpdateIndex(fx.Context(), &UpdateIndexRequest{
 			Index: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -209,7 +211,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateIndex(fx.ctx, &UpdateIndexRequest{
+		_, err := fx.service.UpdateIndex(fx.Context(), &UpdateIndexRequest{
 			Index: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -218,7 +220,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateIndex(fx.ctx, &UpdateIndexRequest{
+		_, err := fx.service.UpdateIndex(fx.Context(), &UpdateIndexRequest{
 			Index: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -242,7 +244,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateIndex(fx.ctx, &UpdateIndexRequest{
+			_, err := fx.service.UpdateIndex(fx.Context(), &UpdateIndexRequest{
 				Index: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -261,7 +263,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateIndex(fx.ctx, &UpdateIndexRequest{
+			_, err := fx.service.UpdateIndex(fx.Context(), &UpdateIndexRequest{
 				Index: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -280,7 +282,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListIndexes(fx.ctx, &ListIndexesRequest{
+		_, err := fx.service.ListIndexes(fx.Context(), &ListIndexesRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -290,7 +292,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListIndexes(fx.ctx, &ListIndexesRequest{
+		_, err := fx.service.ListIndexes(fx.Context(), &ListIndexesRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -301,7 +303,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListIndexes(fx.ctx, &ListIndexesRequest{
+		_, err := fx.service.ListIndexes(fx.Context(), &ListIndexesRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -319,7 +321,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListIndexes(fx.ctx, &ListIndexesRequest{
+		response, err := fx.service.ListIndexes(fx.Context(), &ListIndexesRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -338,7 +340,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListIndexes(fx.ctx, &ListIndexesRequest{
+		response, err := fx.service.ListIndexes(fx.Context(), &ListIndexesRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -349,7 +351,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListIndexes(fx.ctx, &ListIndexesRequest{
+		response, err := fx.service.ListIndexes(fx.Context(), &ListIndexesRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -363,7 +365,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*Index, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListIndexes(fx.ctx, &ListIndexesRequest{
+			response, err := fx.service.ListIndexes(fx.Context(), &ListIndexesRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -392,12 +394,12 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteIndex(fx.ctx, &DeleteIndexRequest{
+			_, err := fx.service.DeleteIndex(fx.Context(), &DeleteIndexRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListIndexes(fx.ctx, &ListIndexesRequest{
+		response, err := fx.service.ListIndexes(fx.Context(), &ListIndexesRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -420,7 +422,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteIndex(fx.ctx, &DeleteIndexRequest{
+		_, err := fx.service.DeleteIndex(fx.Context(), &DeleteIndexRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -429,7 +431,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteIndex(fx.ctx, &DeleteIndexRequest{
+		_, err := fx.service.DeleteIndex(fx.Context(), &DeleteIndexRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -440,7 +442,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteIndex(fx.ctx, &DeleteIndexRequest{
+		_, err := fx.service.DeleteIndex(fx.Context(), &DeleteIndexRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -451,7 +453,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteIndex(fx.ctx, &DeleteIndexRequest{
+		_, err := fx.service.DeleteIndex(fx.Context(), &DeleteIndexRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -462,12 +464,12 @@ func (fx *IndexServiceIndexTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteIndex(fx.ctx, &DeleteIndexRequest{
+		deleted, err := fx.service.DeleteIndex(fx.Context(), &DeleteIndexRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteIndex(fx.ctx, &DeleteIndexRequest{
+		_, err = fx.service.DeleteIndex(fx.Context(), &DeleteIndexRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -476,7 +478,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteIndex(fx.ctx, &DeleteIndexRequest{
+		_, err := fx.service.DeleteIndex(fx.Context(), &DeleteIndexRequest{
 			Name: "projects/-/locations/-/indexes/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_service_aiptest.pb.go
@@ -15,6 +15,34 @@ import (
 	testing "testing"
 )
 
+// IndexServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type IndexServiceTestSuiteConfigProvider interface {
+	// IndexServiceIndexTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	IndexTestSuiteConfig(t *testing.T) *IndexServiceIndexTestSuiteConfig
+}
+
+// TestIndexService is the main entrypoint for starting the AIP tests.
+func TestIndexService(t *testing.T, s IndexServiceTestSuiteConfigProvider) {
+	testIndexServiceIndexTestSuiteConfig(t, s)
+}
+
+func testIndexServiceIndexTestSuiteConfig(t *testing.T, s IndexServiceTestSuiteConfigProvider) {
+	t.Run("Index", func(t *testing.T) {
+		config := s.IndexTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method IndexTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method IndexServiceIndexTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type IndexServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
@@ -16,6 +16,148 @@ import (
 	time "time"
 )
 
+// JobServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type JobServiceTestSuiteConfigProvider interface {
+	// JobServiceBatchPredictionJobTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	BatchPredictionJobTestSuiteConfig(t *testing.T) *JobServiceBatchPredictionJobTestSuiteConfig
+	// JobServiceCustomJobTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	CustomJobTestSuiteConfig(t *testing.T) *JobServiceCustomJobTestSuiteConfig
+	// JobServiceDataLabelingJobTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	DataLabelingJobTestSuiteConfig(t *testing.T) *JobServiceDataLabelingJobTestSuiteConfig
+	// JobServiceHyperparameterTuningJobTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	HyperparameterTuningJobTestSuiteConfig(t *testing.T) *JobServiceHyperparameterTuningJobTestSuiteConfig
+	// JobServiceModelDeploymentMonitoringJobTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	ModelDeploymentMonitoringJobTestSuiteConfig(t *testing.T) *JobServiceModelDeploymentMonitoringJobTestSuiteConfig
+	// JobServiceNasJobTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	NasJobTestSuiteConfig(t *testing.T) *JobServiceNasJobTestSuiteConfig
+	// JobServiceNasTrialDetailTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	NasTrialDetailTestSuiteConfig(t *testing.T) *JobServiceNasTrialDetailTestSuiteConfig
+}
+
+// TestJobService is the main entrypoint for starting the AIP tests.
+func TestJobService(t *testing.T, s JobServiceTestSuiteConfigProvider) {
+	testJobServiceBatchPredictionJobTestSuiteConfig(t, s)
+	testJobServiceCustomJobTestSuiteConfig(t, s)
+	testJobServiceDataLabelingJobTestSuiteConfig(t, s)
+	testJobServiceHyperparameterTuningJobTestSuiteConfig(t, s)
+	testJobServiceModelDeploymentMonitoringJobTestSuiteConfig(t, s)
+	testJobServiceNasJobTestSuiteConfig(t, s)
+	testJobServiceNasTrialDetailTestSuiteConfig(t, s)
+}
+
+func testJobServiceBatchPredictionJobTestSuiteConfig(t *testing.T, s JobServiceTestSuiteConfigProvider) {
+	t.Run("BatchPredictionJob", func(t *testing.T) {
+		config := s.BatchPredictionJobTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method BatchPredictionJobTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method JobServiceBatchPredictionJobTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testJobServiceCustomJobTestSuiteConfig(t *testing.T, s JobServiceTestSuiteConfigProvider) {
+	t.Run("CustomJob", func(t *testing.T) {
+		config := s.CustomJobTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method CustomJobTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method JobServiceCustomJobTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testJobServiceDataLabelingJobTestSuiteConfig(t *testing.T, s JobServiceTestSuiteConfigProvider) {
+	t.Run("DataLabelingJob", func(t *testing.T) {
+		config := s.DataLabelingJobTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method DataLabelingJobTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method JobServiceDataLabelingJobTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testJobServiceHyperparameterTuningJobTestSuiteConfig(t *testing.T, s JobServiceTestSuiteConfigProvider) {
+	t.Run("HyperparameterTuningJob", func(t *testing.T) {
+		config := s.HyperparameterTuningJobTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method HyperparameterTuningJobTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method JobServiceHyperparameterTuningJobTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testJobServiceModelDeploymentMonitoringJobTestSuiteConfig(t *testing.T, s JobServiceTestSuiteConfigProvider) {
+	t.Run("ModelDeploymentMonitoringJob", func(t *testing.T) {
+		config := s.ModelDeploymentMonitoringJobTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method ModelDeploymentMonitoringJobTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method JobServiceModelDeploymentMonitoringJobTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testJobServiceNasJobTestSuiteConfig(t *testing.T, s JobServiceTestSuiteConfigProvider) {
+	t.Run("NasJob", func(t *testing.T) {
+		config := s.NasJobTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method NasJobTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method JobServiceNasJobTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testJobServiceNasTrialDetailTestSuiteConfig(t *testing.T, s JobServiceTestSuiteConfigProvider) {
+	t.Run("NasTrialDetail", func(t *testing.T) {
+		config := s.NasTrialDetailTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method NasTrialDetailTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method JobServiceNasTrialDetailTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type JobServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
@@ -24,7 +24,7 @@ type JobServiceTestSuite struct {
 
 func (fx JobServiceTestSuite) TestBatchPredictionJob(ctx context.Context, options JobServiceBatchPredictionJobTestSuiteConfig) {
 	fx.T.Run("BatchPredictionJob", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -32,7 +32,7 @@ func (fx JobServiceTestSuite) TestBatchPredictionJob(ctx context.Context, option
 
 func (fx JobServiceTestSuite) TestCustomJob(ctx context.Context, options JobServiceCustomJobTestSuiteConfig) {
 	fx.T.Run("CustomJob", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -40,7 +40,7 @@ func (fx JobServiceTestSuite) TestCustomJob(ctx context.Context, options JobServ
 
 func (fx JobServiceTestSuite) TestDataLabelingJob(ctx context.Context, options JobServiceDataLabelingJobTestSuiteConfig) {
 	fx.T.Run("DataLabelingJob", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -48,7 +48,7 @@ func (fx JobServiceTestSuite) TestDataLabelingJob(ctx context.Context, options J
 
 func (fx JobServiceTestSuite) TestHyperparameterTuningJob(ctx context.Context, options JobServiceHyperparameterTuningJobTestSuiteConfig) {
 	fx.T.Run("HyperparameterTuningJob", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -56,7 +56,7 @@ func (fx JobServiceTestSuite) TestHyperparameterTuningJob(ctx context.Context, o
 
 func (fx JobServiceTestSuite) TestModelDeploymentMonitoringJob(ctx context.Context, options JobServiceModelDeploymentMonitoringJobTestSuiteConfig) {
 	fx.T.Run("ModelDeploymentMonitoringJob", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -64,7 +64,7 @@ func (fx JobServiceTestSuite) TestModelDeploymentMonitoringJob(ctx context.Conte
 
 func (fx JobServiceTestSuite) TestNasJob(ctx context.Context, options JobServiceNasJobTestSuiteConfig) {
 	fx.T.Run("NasJob", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -72,17 +72,19 @@ func (fx JobServiceTestSuite) TestNasJob(ctx context.Context, options JobService
 
 func (fx JobServiceTestSuite) TestNasTrialDetail(ctx context.Context, options JobServiceNasTrialDetailTestSuiteConfig) {
 	fx.T.Run("NasTrialDetail", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
 }
 
 type JobServiceBatchPredictionJobTestSuiteConfig struct {
-	ctx        context.Context
 	service    JobServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -110,7 +112,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+		_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 			Parent:             "",
 			BatchPredictionJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -120,7 +122,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+		_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 			Parent:             "invalid resource name",
 			BatchPredictionJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -132,7 +134,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		beforeCreate := time.Now()
-		msg, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+		msg, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 			Parent:             parent,
 			BatchPredictionJob: fx.Create(parent),
 		})
@@ -146,12 +148,12 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+		msg, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 			Parent:             parent,
 			BatchPredictionJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetBatchPredictionJob(fx.ctx, &GetBatchPredictionJobRequest{
+		persisted, err := fx.service.GetBatchPredictionJob(fx.Context(), &GetBatchPredictionJobRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -172,7 +174,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -188,7 +190,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("image_uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -204,7 +206,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("input_config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -220,7 +222,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("uris")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -236,7 +238,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("input_uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -252,7 +254,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("instances_format")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -268,7 +270,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -284,7 +286,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_uri_prefix")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -300,7 +302,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -316,7 +318,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("predictions_format")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -332,7 +334,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("machine_spec")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -348,7 +350,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("parameters")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -364,7 +366,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("path_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -380,7 +382,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("step_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -396,7 +398,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("step_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -412,7 +414,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("inputs")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -428,7 +430,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("outputs")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -444,7 +446,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -465,7 +467,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testCreate(t *testing.T) 
 				t.Skip("not reachable")
 			}
 			container.Model = "invalid resource name"
-			_, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+			_, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 				Parent:             parent,
 				BatchPredictionJob: msg,
 			})
@@ -480,7 +482,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetBatchPredictionJob(fx.ctx, &GetBatchPredictionJobRequest{
+		_, err := fx.service.GetBatchPredictionJob(fx.Context(), &GetBatchPredictionJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -489,7 +491,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetBatchPredictionJob(fx.ctx, &GetBatchPredictionJobRequest{
+		_, err := fx.service.GetBatchPredictionJob(fx.Context(), &GetBatchPredictionJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -500,7 +502,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetBatchPredictionJob(fx.ctx, &GetBatchPredictionJobRequest{
+		msg, err := fx.service.GetBatchPredictionJob(fx.Context(), &GetBatchPredictionJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -512,7 +514,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetBatchPredictionJob(fx.ctx, &GetBatchPredictionJobRequest{
+		_, err := fx.service.GetBatchPredictionJob(fx.Context(), &GetBatchPredictionJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -521,7 +523,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetBatchPredictionJob(fx.ctx, &GetBatchPredictionJobRequest{
+		_, err := fx.service.GetBatchPredictionJob(fx.Context(), &GetBatchPredictionJobRequest{
 			Name: "projects/-/locations/-/batchPredictionJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -534,7 +536,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListBatchPredictionJobs(fx.ctx, &ListBatchPredictionJobsRequest{
+		_, err := fx.service.ListBatchPredictionJobs(fx.Context(), &ListBatchPredictionJobsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -544,7 +546,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListBatchPredictionJobs(fx.ctx, &ListBatchPredictionJobsRequest{
+		_, err := fx.service.ListBatchPredictionJobs(fx.Context(), &ListBatchPredictionJobsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -555,7 +557,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListBatchPredictionJobs(fx.ctx, &ListBatchPredictionJobsRequest{
+		_, err := fx.service.ListBatchPredictionJobs(fx.Context(), &ListBatchPredictionJobsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -573,7 +575,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListBatchPredictionJobs(fx.ctx, &ListBatchPredictionJobsRequest{
+		response, err := fx.service.ListBatchPredictionJobs(fx.Context(), &ListBatchPredictionJobsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -592,7 +594,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListBatchPredictionJobs(fx.ctx, &ListBatchPredictionJobsRequest{
+		response, err := fx.service.ListBatchPredictionJobs(fx.Context(), &ListBatchPredictionJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -603,7 +605,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListBatchPredictionJobs(fx.ctx, &ListBatchPredictionJobsRequest{
+		response, err := fx.service.ListBatchPredictionJobs(fx.Context(), &ListBatchPredictionJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -617,7 +619,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*BatchPredictionJob, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListBatchPredictionJobs(fx.ctx, &ListBatchPredictionJobsRequest{
+			response, err := fx.service.ListBatchPredictionJobs(fx.Context(), &ListBatchPredictionJobsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -646,12 +648,12 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteBatchPredictionJob(fx.ctx, &DeleteBatchPredictionJobRequest{
+			_, err := fx.service.DeleteBatchPredictionJob(fx.Context(), &DeleteBatchPredictionJobRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListBatchPredictionJobs(fx.ctx, &ListBatchPredictionJobsRequest{
+		response, err := fx.service.ListBatchPredictionJobs(fx.Context(), &ListBatchPredictionJobsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -674,7 +676,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testDelete(t *testing.T) 
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteBatchPredictionJob(fx.ctx, &DeleteBatchPredictionJobRequest{
+		_, err := fx.service.DeleteBatchPredictionJob(fx.Context(), &DeleteBatchPredictionJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -683,7 +685,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testDelete(t *testing.T) 
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteBatchPredictionJob(fx.ctx, &DeleteBatchPredictionJobRequest{
+		_, err := fx.service.DeleteBatchPredictionJob(fx.Context(), &DeleteBatchPredictionJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -694,7 +696,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testDelete(t *testing.T) 
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteBatchPredictionJob(fx.ctx, &DeleteBatchPredictionJobRequest{
+		_, err := fx.service.DeleteBatchPredictionJob(fx.Context(), &DeleteBatchPredictionJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -705,7 +707,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testDelete(t *testing.T) 
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteBatchPredictionJob(fx.ctx, &DeleteBatchPredictionJobRequest{
+		_, err := fx.service.DeleteBatchPredictionJob(fx.Context(), &DeleteBatchPredictionJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -716,12 +718,12 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testDelete(t *testing.T) 
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteBatchPredictionJob(fx.ctx, &DeleteBatchPredictionJobRequest{
+		deleted, err := fx.service.DeleteBatchPredictionJob(fx.Context(), &DeleteBatchPredictionJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteBatchPredictionJob(fx.ctx, &DeleteBatchPredictionJobRequest{
+		_, err = fx.service.DeleteBatchPredictionJob(fx.Context(), &DeleteBatchPredictionJobRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -730,7 +732,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testDelete(t *testing.T) 
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteBatchPredictionJob(fx.ctx, &DeleteBatchPredictionJobRequest{
+		_, err := fx.service.DeleteBatchPredictionJob(fx.Context(), &DeleteBatchPredictionJobRequest{
 			Name: "projects/-/locations/-/batchPredictionJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -766,7 +768,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) maybeSkip(t *testing.T) {
 
 func (fx *JobServiceBatchPredictionJobTestSuiteConfig) create(t *testing.T, parent string) *BatchPredictionJob {
 	t.Helper()
-	created, err := fx.service.CreateBatchPredictionJob(fx.ctx, &CreateBatchPredictionJobRequest{
+	created, err := fx.service.CreateBatchPredictionJob(fx.Context(), &CreateBatchPredictionJobRequest{
 		Parent:             parent,
 		BatchPredictionJob: fx.Create(parent),
 	})
@@ -775,10 +777,12 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) create(t *testing.T, pare
 }
 
 type JobServiceCustomJobTestSuiteConfig struct {
-	ctx        context.Context
 	service    JobServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -806,7 +810,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+		_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 			Parent:    "",
 			CustomJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -816,7 +820,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+		_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 			Parent:    "invalid resource name",
 			CustomJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -828,7 +832,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		beforeCreate := time.Now()
-		msg, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+		msg, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 			Parent:    parent,
 			CustomJob: fx.Create(parent),
 		})
@@ -842,12 +846,12 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+		msg, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 			Parent:    parent,
 			CustomJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetCustomJob(fx.ctx, &GetCustomJobRequest{
+		persisted, err := fx.service.GetCustomJob(fx.Context(), &GetCustomJobRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -868,7 +872,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -884,7 +888,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("job_spec")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -900,7 +904,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("worker_pool_specs")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -916,7 +920,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_uri_prefix")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -932,7 +936,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -953,7 +957,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Network = "invalid resource name"
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -968,7 +972,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Tensorboard = "invalid resource name"
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -983,7 +987,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Experiment = "invalid resource name"
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -998,7 +1002,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.ExperimentRun = "invalid resource name"
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -1013,7 +1017,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Models = []string{"invalid resource name"}
-			_, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+			_, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 				Parent:    parent,
 				CustomJob: msg,
 			})
@@ -1028,7 +1032,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetCustomJob(fx.ctx, &GetCustomJobRequest{
+		_, err := fx.service.GetCustomJob(fx.Context(), &GetCustomJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1037,7 +1041,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetCustomJob(fx.ctx, &GetCustomJobRequest{
+		_, err := fx.service.GetCustomJob(fx.Context(), &GetCustomJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1048,7 +1052,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetCustomJob(fx.ctx, &GetCustomJobRequest{
+		msg, err := fx.service.GetCustomJob(fx.Context(), &GetCustomJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1060,7 +1064,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetCustomJob(fx.ctx, &GetCustomJobRequest{
+		_, err := fx.service.GetCustomJob(fx.Context(), &GetCustomJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1069,7 +1073,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetCustomJob(fx.ctx, &GetCustomJobRequest{
+		_, err := fx.service.GetCustomJob(fx.Context(), &GetCustomJobRequest{
 			Name: "projects/-/locations/-/customJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1082,7 +1086,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListCustomJobs(fx.ctx, &ListCustomJobsRequest{
+		_, err := fx.service.ListCustomJobs(fx.Context(), &ListCustomJobsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1092,7 +1096,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListCustomJobs(fx.ctx, &ListCustomJobsRequest{
+		_, err := fx.service.ListCustomJobs(fx.Context(), &ListCustomJobsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -1103,7 +1107,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListCustomJobs(fx.ctx, &ListCustomJobsRequest{
+		_, err := fx.service.ListCustomJobs(fx.Context(), &ListCustomJobsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -1121,7 +1125,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListCustomJobs(fx.ctx, &ListCustomJobsRequest{
+		response, err := fx.service.ListCustomJobs(fx.Context(), &ListCustomJobsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -1140,7 +1144,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListCustomJobs(fx.ctx, &ListCustomJobsRequest{
+		response, err := fx.service.ListCustomJobs(fx.Context(), &ListCustomJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -1151,7 +1155,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListCustomJobs(fx.ctx, &ListCustomJobsRequest{
+		response, err := fx.service.ListCustomJobs(fx.Context(), &ListCustomJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -1165,7 +1169,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*CustomJob, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListCustomJobs(fx.ctx, &ListCustomJobsRequest{
+			response, err := fx.service.ListCustomJobs(fx.Context(), &ListCustomJobsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -1194,12 +1198,12 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteCustomJob(fx.ctx, &DeleteCustomJobRequest{
+			_, err := fx.service.DeleteCustomJob(fx.Context(), &DeleteCustomJobRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListCustomJobs(fx.ctx, &ListCustomJobsRequest{
+		response, err := fx.service.ListCustomJobs(fx.Context(), &ListCustomJobsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -1222,7 +1226,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteCustomJob(fx.ctx, &DeleteCustomJobRequest{
+		_, err := fx.service.DeleteCustomJob(fx.Context(), &DeleteCustomJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1231,7 +1235,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteCustomJob(fx.ctx, &DeleteCustomJobRequest{
+		_, err := fx.service.DeleteCustomJob(fx.Context(), &DeleteCustomJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1242,7 +1246,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteCustomJob(fx.ctx, &DeleteCustomJobRequest{
+		_, err := fx.service.DeleteCustomJob(fx.Context(), &DeleteCustomJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1253,7 +1257,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteCustomJob(fx.ctx, &DeleteCustomJobRequest{
+		_, err := fx.service.DeleteCustomJob(fx.Context(), &DeleteCustomJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1264,12 +1268,12 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteCustomJob(fx.ctx, &DeleteCustomJobRequest{
+		deleted, err := fx.service.DeleteCustomJob(fx.Context(), &DeleteCustomJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteCustomJob(fx.ctx, &DeleteCustomJobRequest{
+		_, err = fx.service.DeleteCustomJob(fx.Context(), &DeleteCustomJobRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1278,7 +1282,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteCustomJob(fx.ctx, &DeleteCustomJobRequest{
+		_, err := fx.service.DeleteCustomJob(fx.Context(), &DeleteCustomJobRequest{
 			Name: "projects/-/locations/-/customJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1314,7 +1318,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) maybeSkip(t *testing.T) {
 
 func (fx *JobServiceCustomJobTestSuiteConfig) create(t *testing.T, parent string) *CustomJob {
 	t.Helper()
-	created, err := fx.service.CreateCustomJob(fx.ctx, &CreateCustomJobRequest{
+	created, err := fx.service.CreateCustomJob(fx.Context(), &CreateCustomJobRequest{
 		Parent:    parent,
 		CustomJob: fx.Create(parent),
 	})
@@ -1323,10 +1327,12 @@ func (fx *JobServiceCustomJobTestSuiteConfig) create(t *testing.T, parent string
 }
 
 type JobServiceDataLabelingJobTestSuiteConfig struct {
-	ctx        context.Context
 	service    JobServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -1354,7 +1360,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+		_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 			Parent:          "",
 			DataLabelingJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -1364,7 +1370,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+		_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 			Parent:          "invalid resource name",
 			DataLabelingJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -1376,7 +1382,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		beforeCreate := time.Now()
-		msg, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+		msg, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 			Parent:          parent,
 			DataLabelingJob: fx.Create(parent),
 		})
@@ -1390,12 +1396,12 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+		msg, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 			Parent:          parent,
 			DataLabelingJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetDataLabelingJob(fx.ctx, &GetDataLabelingJobRequest{
+		persisted, err := fx.service.GetDataLabelingJob(fx.Context(), &GetDataLabelingJobRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -1416,7 +1422,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+			_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 				Parent:          parent,
 				DataLabelingJob: msg,
 			})
@@ -1432,7 +1438,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("datasets")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+			_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 				Parent:          parent,
 				DataLabelingJob: msg,
 			})
@@ -1448,7 +1454,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("labeler_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+			_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 				Parent:          parent,
 				DataLabelingJob: msg,
 			})
@@ -1464,7 +1470,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("instruction_uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+			_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 				Parent:          parent,
 				DataLabelingJob: msg,
 			})
@@ -1480,7 +1486,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("inputs_schema_uri")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+			_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 				Parent:          parent,
 				DataLabelingJob: msg,
 			})
@@ -1496,7 +1502,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("inputs")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+			_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 				Parent:          parent,
 				DataLabelingJob: msg,
 			})
@@ -1512,7 +1518,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+			_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 				Parent:          parent,
 				DataLabelingJob: msg,
 			})
@@ -1533,7 +1539,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Datasets = []string{"invalid resource name"}
-			_, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+			_, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 				Parent:          parent,
 				DataLabelingJob: msg,
 			})
@@ -1548,7 +1554,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetDataLabelingJob(fx.ctx, &GetDataLabelingJobRequest{
+		_, err := fx.service.GetDataLabelingJob(fx.Context(), &GetDataLabelingJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1557,7 +1563,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetDataLabelingJob(fx.ctx, &GetDataLabelingJobRequest{
+		_, err := fx.service.GetDataLabelingJob(fx.Context(), &GetDataLabelingJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1568,7 +1574,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetDataLabelingJob(fx.ctx, &GetDataLabelingJobRequest{
+		msg, err := fx.service.GetDataLabelingJob(fx.Context(), &GetDataLabelingJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1580,7 +1586,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetDataLabelingJob(fx.ctx, &GetDataLabelingJobRequest{
+		_, err := fx.service.GetDataLabelingJob(fx.Context(), &GetDataLabelingJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1589,7 +1595,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetDataLabelingJob(fx.ctx, &GetDataLabelingJobRequest{
+		_, err := fx.service.GetDataLabelingJob(fx.Context(), &GetDataLabelingJobRequest{
 			Name: "projects/-/locations/-/dataLabelingJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1602,7 +1608,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListDataLabelingJobs(fx.ctx, &ListDataLabelingJobsRequest{
+		_, err := fx.service.ListDataLabelingJobs(fx.Context(), &ListDataLabelingJobsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1612,7 +1618,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListDataLabelingJobs(fx.ctx, &ListDataLabelingJobsRequest{
+		_, err := fx.service.ListDataLabelingJobs(fx.Context(), &ListDataLabelingJobsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -1623,7 +1629,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListDataLabelingJobs(fx.ctx, &ListDataLabelingJobsRequest{
+		_, err := fx.service.ListDataLabelingJobs(fx.Context(), &ListDataLabelingJobsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -1641,7 +1647,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListDataLabelingJobs(fx.ctx, &ListDataLabelingJobsRequest{
+		response, err := fx.service.ListDataLabelingJobs(fx.Context(), &ListDataLabelingJobsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -1660,7 +1666,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListDataLabelingJobs(fx.ctx, &ListDataLabelingJobsRequest{
+		response, err := fx.service.ListDataLabelingJobs(fx.Context(), &ListDataLabelingJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -1671,7 +1677,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListDataLabelingJobs(fx.ctx, &ListDataLabelingJobsRequest{
+		response, err := fx.service.ListDataLabelingJobs(fx.Context(), &ListDataLabelingJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -1685,7 +1691,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*DataLabelingJob, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListDataLabelingJobs(fx.ctx, &ListDataLabelingJobsRequest{
+			response, err := fx.service.ListDataLabelingJobs(fx.Context(), &ListDataLabelingJobsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -1714,12 +1720,12 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteDataLabelingJob(fx.ctx, &DeleteDataLabelingJobRequest{
+			_, err := fx.service.DeleteDataLabelingJob(fx.Context(), &DeleteDataLabelingJobRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListDataLabelingJobs(fx.ctx, &ListDataLabelingJobsRequest{
+		response, err := fx.service.ListDataLabelingJobs(fx.Context(), &ListDataLabelingJobsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -1742,7 +1748,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteDataLabelingJob(fx.ctx, &DeleteDataLabelingJobRequest{
+		_, err := fx.service.DeleteDataLabelingJob(fx.Context(), &DeleteDataLabelingJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1751,7 +1757,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteDataLabelingJob(fx.ctx, &DeleteDataLabelingJobRequest{
+		_, err := fx.service.DeleteDataLabelingJob(fx.Context(), &DeleteDataLabelingJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1762,7 +1768,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteDataLabelingJob(fx.ctx, &DeleteDataLabelingJobRequest{
+		_, err := fx.service.DeleteDataLabelingJob(fx.Context(), &DeleteDataLabelingJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1773,7 +1779,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteDataLabelingJob(fx.ctx, &DeleteDataLabelingJobRequest{
+		_, err := fx.service.DeleteDataLabelingJob(fx.Context(), &DeleteDataLabelingJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1784,12 +1790,12 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteDataLabelingJob(fx.ctx, &DeleteDataLabelingJobRequest{
+		deleted, err := fx.service.DeleteDataLabelingJob(fx.Context(), &DeleteDataLabelingJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteDataLabelingJob(fx.ctx, &DeleteDataLabelingJobRequest{
+		_, err = fx.service.DeleteDataLabelingJob(fx.Context(), &DeleteDataLabelingJobRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1798,7 +1804,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteDataLabelingJob(fx.ctx, &DeleteDataLabelingJobRequest{
+		_, err := fx.service.DeleteDataLabelingJob(fx.Context(), &DeleteDataLabelingJobRequest{
 			Name: "projects/-/locations/-/dataLabelingJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1834,7 +1840,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) maybeSkip(t *testing.T) {
 
 func (fx *JobServiceDataLabelingJobTestSuiteConfig) create(t *testing.T, parent string) *DataLabelingJob {
 	t.Helper()
-	created, err := fx.service.CreateDataLabelingJob(fx.ctx, &CreateDataLabelingJobRequest{
+	created, err := fx.service.CreateDataLabelingJob(fx.Context(), &CreateDataLabelingJobRequest{
 		Parent:          parent,
 		DataLabelingJob: fx.Create(parent),
 	})
@@ -1843,10 +1849,12 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) create(t *testing.T, parent 
 }
 
 type JobServiceHyperparameterTuningJobTestSuiteConfig struct {
-	ctx        context.Context
 	service    JobServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -1874,7 +1882,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+		_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 			Parent:                  "",
 			HyperparameterTuningJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -1884,7 +1892,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+		_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 			Parent:                  "invalid resource name",
 			HyperparameterTuningJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -1896,7 +1904,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		beforeCreate := time.Now()
-		msg, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+		msg, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 			Parent:                  parent,
 			HyperparameterTuningJob: fx.Create(parent),
 		})
@@ -1910,12 +1918,12 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+		msg, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 			Parent:                  parent,
 			HyperparameterTuningJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetHyperparameterTuningJob(fx.ctx, &GetHyperparameterTuningJobRequest{
+		persisted, err := fx.service.GetHyperparameterTuningJob(fx.Context(), &GetHyperparameterTuningJobRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -1936,7 +1944,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -1952,7 +1960,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("study_spec")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -1968,7 +1976,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("metrics")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -1984,7 +1992,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("parameters")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2000,7 +2008,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_trial_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2016,7 +2024,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("parallel_trial_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2032,7 +2040,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("trial_job_spec")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2048,7 +2056,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("worker_pool_specs")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2064,7 +2072,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_uri_prefix")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2080,7 +2088,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2101,7 +2109,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 				t.Skip("not reachable")
 			}
 			container.Network = "invalid resource name"
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2116,7 +2124,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 				t.Skip("not reachable")
 			}
 			container.Tensorboard = "invalid resource name"
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2131,7 +2139,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 				t.Skip("not reachable")
 			}
 			container.Experiment = "invalid resource name"
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2146,7 +2154,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 				t.Skip("not reachable")
 			}
 			container.ExperimentRun = "invalid resource name"
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2161,7 +2169,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testCreate(t *testin
 				t.Skip("not reachable")
 			}
 			container.Models = []string{"invalid resource name"}
-			_, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+			_, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 				Parent:                  parent,
 				HyperparameterTuningJob: msg,
 			})
@@ -2176,7 +2184,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testGet(t *testing.T
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetHyperparameterTuningJob(fx.ctx, &GetHyperparameterTuningJobRequest{
+		_, err := fx.service.GetHyperparameterTuningJob(fx.Context(), &GetHyperparameterTuningJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2185,7 +2193,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testGet(t *testing.T
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetHyperparameterTuningJob(fx.ctx, &GetHyperparameterTuningJobRequest{
+		_, err := fx.service.GetHyperparameterTuningJob(fx.Context(), &GetHyperparameterTuningJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2196,7 +2204,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testGet(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetHyperparameterTuningJob(fx.ctx, &GetHyperparameterTuningJobRequest{
+		msg, err := fx.service.GetHyperparameterTuningJob(fx.Context(), &GetHyperparameterTuningJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -2208,7 +2216,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testGet(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetHyperparameterTuningJob(fx.ctx, &GetHyperparameterTuningJobRequest{
+		_, err := fx.service.GetHyperparameterTuningJob(fx.Context(), &GetHyperparameterTuningJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -2217,7 +2225,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testGet(t *testing.T
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetHyperparameterTuningJob(fx.ctx, &GetHyperparameterTuningJobRequest{
+		_, err := fx.service.GetHyperparameterTuningJob(fx.Context(), &GetHyperparameterTuningJobRequest{
 			Name: "projects/-/locations/-/hyperparameterTuningJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2230,7 +2238,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListHyperparameterTuningJobs(fx.ctx, &ListHyperparameterTuningJobsRequest{
+		_, err := fx.service.ListHyperparameterTuningJobs(fx.Context(), &ListHyperparameterTuningJobsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2240,7 +2248,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListHyperparameterTuningJobs(fx.ctx, &ListHyperparameterTuningJobsRequest{
+		_, err := fx.service.ListHyperparameterTuningJobs(fx.Context(), &ListHyperparameterTuningJobsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -2251,7 +2259,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListHyperparameterTuningJobs(fx.ctx, &ListHyperparameterTuningJobsRequest{
+		_, err := fx.service.ListHyperparameterTuningJobs(fx.Context(), &ListHyperparameterTuningJobsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -2269,7 +2277,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListHyperparameterTuningJobs(fx.ctx, &ListHyperparameterTuningJobsRequest{
+		response, err := fx.service.ListHyperparameterTuningJobs(fx.Context(), &ListHyperparameterTuningJobsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -2288,7 +2296,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListHyperparameterTuningJobs(fx.ctx, &ListHyperparameterTuningJobsRequest{
+		response, err := fx.service.ListHyperparameterTuningJobs(fx.Context(), &ListHyperparameterTuningJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -2299,7 +2307,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListHyperparameterTuningJobs(fx.ctx, &ListHyperparameterTuningJobsRequest{
+		response, err := fx.service.ListHyperparameterTuningJobs(fx.Context(), &ListHyperparameterTuningJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -2313,7 +2321,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 		msgs := make([]*HyperparameterTuningJob, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListHyperparameterTuningJobs(fx.ctx, &ListHyperparameterTuningJobsRequest{
+			response, err := fx.service.ListHyperparameterTuningJobs(fx.Context(), &ListHyperparameterTuningJobsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -2342,12 +2350,12 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteHyperparameterTuningJob(fx.ctx, &DeleteHyperparameterTuningJobRequest{
+			_, err := fx.service.DeleteHyperparameterTuningJob(fx.Context(), &DeleteHyperparameterTuningJobRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListHyperparameterTuningJobs(fx.ctx, &ListHyperparameterTuningJobsRequest{
+		response, err := fx.service.ListHyperparameterTuningJobs(fx.Context(), &ListHyperparameterTuningJobsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -2370,7 +2378,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testDelete(t *testin
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteHyperparameterTuningJob(fx.ctx, &DeleteHyperparameterTuningJobRequest{
+		_, err := fx.service.DeleteHyperparameterTuningJob(fx.Context(), &DeleteHyperparameterTuningJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2379,7 +2387,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testDelete(t *testin
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteHyperparameterTuningJob(fx.ctx, &DeleteHyperparameterTuningJobRequest{
+		_, err := fx.service.DeleteHyperparameterTuningJob(fx.Context(), &DeleteHyperparameterTuningJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2390,7 +2398,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testDelete(t *testin
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteHyperparameterTuningJob(fx.ctx, &DeleteHyperparameterTuningJobRequest{
+		_, err := fx.service.DeleteHyperparameterTuningJob(fx.Context(), &DeleteHyperparameterTuningJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -2401,7 +2409,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testDelete(t *testin
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteHyperparameterTuningJob(fx.ctx, &DeleteHyperparameterTuningJobRequest{
+		_, err := fx.service.DeleteHyperparameterTuningJob(fx.Context(), &DeleteHyperparameterTuningJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -2412,12 +2420,12 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testDelete(t *testin
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteHyperparameterTuningJob(fx.ctx, &DeleteHyperparameterTuningJobRequest{
+		deleted, err := fx.service.DeleteHyperparameterTuningJob(fx.Context(), &DeleteHyperparameterTuningJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteHyperparameterTuningJob(fx.ctx, &DeleteHyperparameterTuningJobRequest{
+		_, err = fx.service.DeleteHyperparameterTuningJob(fx.Context(), &DeleteHyperparameterTuningJobRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -2426,7 +2434,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testDelete(t *testin
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteHyperparameterTuningJob(fx.ctx, &DeleteHyperparameterTuningJobRequest{
+		_, err := fx.service.DeleteHyperparameterTuningJob(fx.Context(), &DeleteHyperparameterTuningJobRequest{
 			Name: "projects/-/locations/-/hyperparameterTuningJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2462,7 +2470,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) maybeSkip(t *testing
 
 func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) create(t *testing.T, parent string) *HyperparameterTuningJob {
 	t.Helper()
-	created, err := fx.service.CreateHyperparameterTuningJob(fx.ctx, &CreateHyperparameterTuningJobRequest{
+	created, err := fx.service.CreateHyperparameterTuningJob(fx.Context(), &CreateHyperparameterTuningJobRequest{
 		Parent:                  parent,
 		HyperparameterTuningJob: fx.Create(parent),
 	})
@@ -2471,10 +2479,12 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) create(t *testing.T,
 }
 
 type JobServiceModelDeploymentMonitoringJobTestSuiteConfig struct {
-	ctx        context.Context
 	service    JobServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -2506,7 +2516,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 			Parent:                       "",
 			ModelDeploymentMonitoringJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -2516,7 +2526,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 			Parent:                       "invalid resource name",
 			ModelDeploymentMonitoringJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -2528,7 +2538,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		beforeCreate := time.Now()
-		msg, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+		msg, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 			Parent:                       parent,
 			ModelDeploymentMonitoringJob: fx.Create(parent),
 		})
@@ -2542,12 +2552,12 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+		msg, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 			Parent:                       parent,
 			ModelDeploymentMonitoringJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetModelDeploymentMonitoringJob(fx.ctx, &GetModelDeploymentMonitoringJobRequest{
+		persisted, err := fx.service.GetModelDeploymentMonitoringJob(fx.Context(), &GetModelDeploymentMonitoringJobRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -2568,7 +2578,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2584,7 +2594,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("endpoint")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2600,7 +2610,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("model_deployment_monitoring_objective_configs")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2616,7 +2626,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("model_deployment_monitoring_schedule_config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2632,7 +2642,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("monitor_interval")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2648,7 +2658,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("logging_sampling_strategy")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2664,7 +2674,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_uri_prefix")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2680,7 +2690,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2701,7 +2711,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 				t.Skip("not reachable")
 			}
 			container.Endpoint = "invalid resource name"
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2716,7 +2726,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testCreate(t *t
 				t.Skip("not reachable")
 			}
 			container.NotificationChannels = []string{"invalid resource name"}
-			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 				Parent:                       parent,
 				ModelDeploymentMonitoringJob: msg,
 			})
@@ -2731,7 +2741,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testGet(t *test
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetModelDeploymentMonitoringJob(fx.ctx, &GetModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.GetModelDeploymentMonitoringJob(fx.Context(), &GetModelDeploymentMonitoringJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2740,7 +2750,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testGet(t *test
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetModelDeploymentMonitoringJob(fx.ctx, &GetModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.GetModelDeploymentMonitoringJob(fx.Context(), &GetModelDeploymentMonitoringJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2751,7 +2761,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testGet(t *test
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetModelDeploymentMonitoringJob(fx.ctx, &GetModelDeploymentMonitoringJobRequest{
+		msg, err := fx.service.GetModelDeploymentMonitoringJob(fx.Context(), &GetModelDeploymentMonitoringJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -2763,7 +2773,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testGet(t *test
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetModelDeploymentMonitoringJob(fx.ctx, &GetModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.GetModelDeploymentMonitoringJob(fx.Context(), &GetModelDeploymentMonitoringJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -2772,7 +2782,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testGet(t *test
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetModelDeploymentMonitoringJob(fx.ctx, &GetModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.GetModelDeploymentMonitoringJob(fx.Context(), &GetModelDeploymentMonitoringJobRequest{
 			Name: "projects/-/locations/-/modelDeploymentMonitoringJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2788,7 +2798,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 			ModelDeploymentMonitoringJob: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2800,7 +2810,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 			ModelDeploymentMonitoringJob: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -2813,7 +2823,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 			ModelDeploymentMonitoringJob: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -2822,7 +2832,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 			ModelDeploymentMonitoringJob: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -2846,7 +2856,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 				ModelDeploymentMonitoringJob: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -2865,7 +2875,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("endpoint")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 				ModelDeploymentMonitoringJob: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -2884,7 +2894,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("model_deployment_monitoring_objective_configs")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 				ModelDeploymentMonitoringJob: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -2903,7 +2913,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("model_deployment_monitoring_schedule_config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 				ModelDeploymentMonitoringJob: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -2922,7 +2932,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("monitor_interval")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 				ModelDeploymentMonitoringJob: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -2941,7 +2951,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("logging_sampling_strategy")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 				ModelDeploymentMonitoringJob: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -2960,7 +2970,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_uri_prefix")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 				ModelDeploymentMonitoringJob: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -2979,7 +2989,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testUpdate(t *t
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.ctx, &UpdateModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.UpdateModelDeploymentMonitoringJob(fx.Context(), &UpdateModelDeploymentMonitoringJobRequest{
 				ModelDeploymentMonitoringJob: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -2998,7 +3008,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListModelDeploymentMonitoringJobs(fx.ctx, &ListModelDeploymentMonitoringJobsRequest{
+		_, err := fx.service.ListModelDeploymentMonitoringJobs(fx.Context(), &ListModelDeploymentMonitoringJobsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3008,7 +3018,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListModelDeploymentMonitoringJobs(fx.ctx, &ListModelDeploymentMonitoringJobsRequest{
+		_, err := fx.service.ListModelDeploymentMonitoringJobs(fx.Context(), &ListModelDeploymentMonitoringJobsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -3019,7 +3029,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListModelDeploymentMonitoringJobs(fx.ctx, &ListModelDeploymentMonitoringJobsRequest{
+		_, err := fx.service.ListModelDeploymentMonitoringJobs(fx.Context(), &ListModelDeploymentMonitoringJobsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -3037,7 +3047,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.ctx, &ListModelDeploymentMonitoringJobsRequest{
+		response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.Context(), &ListModelDeploymentMonitoringJobsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -3056,7 +3066,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.ctx, &ListModelDeploymentMonitoringJobsRequest{
+		response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.Context(), &ListModelDeploymentMonitoringJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -3067,7 +3077,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.ctx, &ListModelDeploymentMonitoringJobsRequest{
+		response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.Context(), &ListModelDeploymentMonitoringJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -3081,7 +3091,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 		msgs := make([]*ModelDeploymentMonitoringJob, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.ctx, &ListModelDeploymentMonitoringJobsRequest{
+			response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.Context(), &ListModelDeploymentMonitoringJobsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -3110,12 +3120,12 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.ctx, &DeleteModelDeploymentMonitoringJobRequest{
+			_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.Context(), &DeleteModelDeploymentMonitoringJobRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.ctx, &ListModelDeploymentMonitoringJobsRequest{
+		response, err := fx.service.ListModelDeploymentMonitoringJobs(fx.Context(), &ListModelDeploymentMonitoringJobsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -3138,7 +3148,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testDelete(t *t
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.ctx, &DeleteModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.Context(), &DeleteModelDeploymentMonitoringJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3147,7 +3157,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testDelete(t *t
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.ctx, &DeleteModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.Context(), &DeleteModelDeploymentMonitoringJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3158,7 +3168,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testDelete(t *t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.ctx, &DeleteModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.Context(), &DeleteModelDeploymentMonitoringJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -3169,7 +3179,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testDelete(t *t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.ctx, &DeleteModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.Context(), &DeleteModelDeploymentMonitoringJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -3180,12 +3190,12 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testDelete(t *t
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.ctx, &DeleteModelDeploymentMonitoringJobRequest{
+		deleted, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.Context(), &DeleteModelDeploymentMonitoringJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteModelDeploymentMonitoringJob(fx.ctx, &DeleteModelDeploymentMonitoringJobRequest{
+		_, err = fx.service.DeleteModelDeploymentMonitoringJob(fx.Context(), &DeleteModelDeploymentMonitoringJobRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -3194,7 +3204,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testDelete(t *t
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.ctx, &DeleteModelDeploymentMonitoringJobRequest{
+		_, err := fx.service.DeleteModelDeploymentMonitoringJob(fx.Context(), &DeleteModelDeploymentMonitoringJobRequest{
 			Name: "projects/-/locations/-/modelDeploymentMonitoringJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3230,7 +3240,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) maybeSkip(t *te
 
 func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) create(t *testing.T, parent string) *ModelDeploymentMonitoringJob {
 	t.Helper()
-	created, err := fx.service.CreateModelDeploymentMonitoringJob(fx.ctx, &CreateModelDeploymentMonitoringJobRequest{
+	created, err := fx.service.CreateModelDeploymentMonitoringJob(fx.Context(), &CreateModelDeploymentMonitoringJobRequest{
 		Parent:                       parent,
 		ModelDeploymentMonitoringJob: fx.Create(parent),
 	})
@@ -3239,10 +3249,12 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) create(t *testi
 }
 
 type JobServiceNasJobTestSuiteConfig struct {
-	ctx        context.Context
 	service    JobServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -3270,7 +3282,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+		_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 			Parent: "",
 			NasJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -3280,7 +3292,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+		_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 			Parent: "invalid resource name",
 			NasJob: fx.Create(fx.nextParent(t, false)),
 		})
@@ -3292,7 +3304,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		beforeCreate := time.Now()
-		msg, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+		msg, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 			Parent: parent,
 			NasJob: fx.Create(parent),
 		})
@@ -3306,12 +3318,12 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+		msg, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 			Parent: parent,
 			NasJob: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetNasJob(fx.ctx, &GetNasJobRequest{
+		persisted, err := fx.service.GetNasJob(fx.Context(), &GetNasJobRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -3332,7 +3344,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3348,7 +3360,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("nas_job_spec")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3364,7 +3376,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("metric_id")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3380,7 +3392,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("goal")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3396,7 +3408,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("search_trial_spec")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3412,7 +3424,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("search_trial_job_spec")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3428,7 +3440,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("worker_pool_specs")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3444,7 +3456,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("output_uri_prefix")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3460,7 +3472,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_trial_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3476,7 +3488,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_parallel_trial_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3492,7 +3504,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("train_trial_job_spec")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3508,7 +3520,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_parallel_trial_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3524,7 +3536,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("frequency")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3540,7 +3552,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3561,7 +3573,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Network = "invalid resource name"
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3576,7 +3588,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Tensorboard = "invalid resource name"
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3591,7 +3603,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Experiment = "invalid resource name"
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3606,7 +3618,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.ExperimentRun = "invalid resource name"
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3621,7 +3633,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Models = []string{"invalid resource name"}
-			_, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+			_, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 				Parent: parent,
 				NasJob: msg,
 			})
@@ -3636,7 +3648,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetNasJob(fx.ctx, &GetNasJobRequest{
+		_, err := fx.service.GetNasJob(fx.Context(), &GetNasJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3645,7 +3657,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetNasJob(fx.ctx, &GetNasJobRequest{
+		_, err := fx.service.GetNasJob(fx.Context(), &GetNasJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3656,7 +3668,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetNasJob(fx.ctx, &GetNasJobRequest{
+		msg, err := fx.service.GetNasJob(fx.Context(), &GetNasJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -3668,7 +3680,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetNasJob(fx.ctx, &GetNasJobRequest{
+		_, err := fx.service.GetNasJob(fx.Context(), &GetNasJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -3677,7 +3689,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetNasJob(fx.ctx, &GetNasJobRequest{
+		_, err := fx.service.GetNasJob(fx.Context(), &GetNasJobRequest{
 			Name: "projects/-/locations/-/nasJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3690,7 +3702,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListNasJobs(fx.ctx, &ListNasJobsRequest{
+		_, err := fx.service.ListNasJobs(fx.Context(), &ListNasJobsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3700,7 +3712,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListNasJobs(fx.ctx, &ListNasJobsRequest{
+		_, err := fx.service.ListNasJobs(fx.Context(), &ListNasJobsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -3711,7 +3723,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListNasJobs(fx.ctx, &ListNasJobsRequest{
+		_, err := fx.service.ListNasJobs(fx.Context(), &ListNasJobsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -3729,7 +3741,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListNasJobs(fx.ctx, &ListNasJobsRequest{
+		response, err := fx.service.ListNasJobs(fx.Context(), &ListNasJobsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -3748,7 +3760,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListNasJobs(fx.ctx, &ListNasJobsRequest{
+		response, err := fx.service.ListNasJobs(fx.Context(), &ListNasJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -3759,7 +3771,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListNasJobs(fx.ctx, &ListNasJobsRequest{
+		response, err := fx.service.ListNasJobs(fx.Context(), &ListNasJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -3773,7 +3785,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*NasJob, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListNasJobs(fx.ctx, &ListNasJobsRequest{
+			response, err := fx.service.ListNasJobs(fx.Context(), &ListNasJobsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -3802,12 +3814,12 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteNasJob(fx.ctx, &DeleteNasJobRequest{
+			_, err := fx.service.DeleteNasJob(fx.Context(), &DeleteNasJobRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListNasJobs(fx.ctx, &ListNasJobsRequest{
+		response, err := fx.service.ListNasJobs(fx.Context(), &ListNasJobsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -3830,7 +3842,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteNasJob(fx.ctx, &DeleteNasJobRequest{
+		_, err := fx.service.DeleteNasJob(fx.Context(), &DeleteNasJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3839,7 +3851,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteNasJob(fx.ctx, &DeleteNasJobRequest{
+		_, err := fx.service.DeleteNasJob(fx.Context(), &DeleteNasJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3850,7 +3862,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteNasJob(fx.ctx, &DeleteNasJobRequest{
+		_, err := fx.service.DeleteNasJob(fx.Context(), &DeleteNasJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -3861,7 +3873,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteNasJob(fx.ctx, &DeleteNasJobRequest{
+		_, err := fx.service.DeleteNasJob(fx.Context(), &DeleteNasJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -3872,12 +3884,12 @@ func (fx *JobServiceNasJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteNasJob(fx.ctx, &DeleteNasJobRequest{
+		deleted, err := fx.service.DeleteNasJob(fx.Context(), &DeleteNasJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteNasJob(fx.ctx, &DeleteNasJobRequest{
+		_, err = fx.service.DeleteNasJob(fx.Context(), &DeleteNasJobRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -3886,7 +3898,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteNasJob(fx.ctx, &DeleteNasJobRequest{
+		_, err := fx.service.DeleteNasJob(fx.Context(), &DeleteNasJobRequest{
 			Name: "projects/-/locations/-/nasJobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3922,7 +3934,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) maybeSkip(t *testing.T) {
 
 func (fx *JobServiceNasJobTestSuiteConfig) create(t *testing.T, parent string) *NasJob {
 	t.Helper()
-	created, err := fx.service.CreateNasJob(fx.ctx, &CreateNasJobRequest{
+	created, err := fx.service.CreateNasJob(fx.Context(), &CreateNasJobRequest{
 		Parent: parent,
 		NasJob: fx.Create(parent),
 	})
@@ -3931,10 +3943,12 @@ func (fx *JobServiceNasJobTestSuiteConfig) create(t *testing.T, parent string) *
 }
 
 type JobServiceNasTrialDetailTestSuiteConfig struct {
-	ctx        context.Context
 	service    JobServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -3963,7 +3977,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetNasTrialDetail(fx.ctx, &GetNasTrialDetailRequest{
+		_, err := fx.service.GetNasTrialDetail(fx.Context(), &GetNasTrialDetailRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3972,7 +3986,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetNasTrialDetail(fx.ctx, &GetNasTrialDetailRequest{
+		_, err := fx.service.GetNasTrialDetail(fx.Context(), &GetNasTrialDetailRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -3983,7 +3997,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetNasTrialDetail(fx.ctx, &GetNasTrialDetailRequest{
+		msg, err := fx.service.GetNasTrialDetail(fx.Context(), &GetNasTrialDetailRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -3995,7 +4009,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetNasTrialDetail(fx.ctx, &GetNasTrialDetailRequest{
+		_, err := fx.service.GetNasTrialDetail(fx.Context(), &GetNasTrialDetailRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -4004,7 +4018,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetNasTrialDetail(fx.ctx, &GetNasTrialDetailRequest{
+		_, err := fx.service.GetNasTrialDetail(fx.Context(), &GetNasTrialDetailRequest{
 			Name: "projects/-/locations/-/nasJobs/-/nasTrialDetails/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -4017,7 +4031,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListNasTrialDetails(fx.ctx, &ListNasTrialDetailsRequest{
+		_, err := fx.service.ListNasTrialDetails(fx.Context(), &ListNasTrialDetailsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -4027,7 +4041,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListNasTrialDetails(fx.ctx, &ListNasTrialDetailsRequest{
+		_, err := fx.service.ListNasTrialDetails(fx.Context(), &ListNasTrialDetailsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -4038,7 +4052,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListNasTrialDetails(fx.ctx, &ListNasTrialDetailsRequest{
+		_, err := fx.service.ListNasTrialDetails(fx.Context(), &ListNasTrialDetailsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -4056,7 +4070,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListNasTrialDetails(fx.ctx, &ListNasTrialDetailsRequest{
+		response, err := fx.service.ListNasTrialDetails(fx.Context(), &ListNasTrialDetailsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -4075,7 +4089,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListNasTrialDetails(fx.ctx, &ListNasTrialDetailsRequest{
+		response, err := fx.service.ListNasTrialDetails(fx.Context(), &ListNasTrialDetailsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -4086,7 +4100,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListNasTrialDetails(fx.ctx, &ListNasTrialDetailsRequest{
+		response, err := fx.service.ListNasTrialDetails(fx.Context(), &ListNasTrialDetailsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -4100,7 +4114,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*NasTrialDetail, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListNasTrialDetails(fx.ctx, &ListNasTrialDetailsRequest{
+			response, err := fx.service.ListNasTrialDetails(fx.Context(), &ListNasTrialDetailsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -4157,7 +4171,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) create(t *testing.T, parent s
 	if fx.CreateResource == nil {
 		t.Skip("Test skipped because CreateResource not specified on JobServiceNasTrialDetailTestSuiteConfig")
 	}
-	created, err := fx.CreateResource(fx.ctx, parent)
+	created, err := fx.CreateResource(fx.Context(), parent)
 	assert.NilError(t, err)
 	return created
 }

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
@@ -15,6 +15,110 @@ import (
 	time "time"
 )
 
+// MetadataServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type MetadataServiceTestSuiteConfigProvider interface {
+	// MetadataServiceArtifactTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	ArtifactTestSuiteConfig(t *testing.T) *MetadataServiceArtifactTestSuiteConfig
+	// MetadataServiceContextTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	ContextTestSuiteConfig(t *testing.T) *MetadataServiceContextTestSuiteConfig
+	// MetadataServiceExecutionTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	ExecutionTestSuiteConfig(t *testing.T) *MetadataServiceExecutionTestSuiteConfig
+	// MetadataServiceMetadataSchemaTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	MetadataSchemaTestSuiteConfig(t *testing.T) *MetadataServiceMetadataSchemaTestSuiteConfig
+	// MetadataServiceMetadataStoreTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	MetadataStoreTestSuiteConfig(t *testing.T) *MetadataServiceMetadataStoreTestSuiteConfig
+}
+
+// TestMetadataService is the main entrypoint for starting the AIP tests.
+func TestMetadataService(t *testing.T, s MetadataServiceTestSuiteConfigProvider) {
+	testMetadataServiceArtifactTestSuiteConfig(t, s)
+	testMetadataServiceContextTestSuiteConfig(t, s)
+	testMetadataServiceExecutionTestSuiteConfig(t, s)
+	testMetadataServiceMetadataSchemaTestSuiteConfig(t, s)
+	testMetadataServiceMetadataStoreTestSuiteConfig(t, s)
+}
+
+func testMetadataServiceArtifactTestSuiteConfig(t *testing.T, s MetadataServiceTestSuiteConfigProvider) {
+	t.Run("Artifact", func(t *testing.T) {
+		config := s.ArtifactTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method ArtifactTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method MetadataServiceArtifactTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testMetadataServiceContextTestSuiteConfig(t *testing.T, s MetadataServiceTestSuiteConfigProvider) {
+	t.Run("Context", func(t *testing.T) {
+		config := s.ContextTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method ContextTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method MetadataServiceContextTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testMetadataServiceExecutionTestSuiteConfig(t *testing.T, s MetadataServiceTestSuiteConfigProvider) {
+	t.Run("Execution", func(t *testing.T) {
+		config := s.ExecutionTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method ExecutionTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method MetadataServiceExecutionTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testMetadataServiceMetadataSchemaTestSuiteConfig(t *testing.T, s MetadataServiceTestSuiteConfigProvider) {
+	t.Run("MetadataSchema", func(t *testing.T) {
+		config := s.MetadataSchemaTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method MetadataSchemaTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method MetadataServiceMetadataSchemaTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testMetadataServiceMetadataStoreTestSuiteConfig(t *testing.T, s MetadataServiceTestSuiteConfigProvider) {
+	t.Run("MetadataStore", func(t *testing.T) {
+		config := s.MetadataStoreTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method MetadataStoreTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method MetadataServiceMetadataStoreTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type MetadataServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/model_garden_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/model_garden_service_aiptest.pb.go
@@ -21,15 +21,17 @@ type ModelGardenServiceTestSuite struct {
 func (fx ModelGardenServiceTestSuite) TestPublisherModel(ctx context.Context, options ModelGardenServicePublisherModelTestSuiteConfig) {
 	fx.T.Run("PublisherModel", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() ModelGardenServiceServer { return fx.Server }
 		options.test(t)
 	})
 }
 
 type ModelGardenServicePublisherModelTestSuiteConfig struct {
-	service    ModelGardenServiceServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() ModelGardenServiceServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -60,7 +62,7 @@ func (fx *ModelGardenServicePublisherModelTestSuiteConfig) testGet(t *testing.T)
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
+		_, err := fx.Service().GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -69,7 +71,7 @@ func (fx *ModelGardenServicePublisherModelTestSuiteConfig) testGet(t *testing.T)
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
+		_, err := fx.Service().GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -80,7 +82,7 @@ func (fx *ModelGardenServicePublisherModelTestSuiteConfig) testGet(t *testing.T)
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
+		msg, err := fx.Service().GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -92,7 +94,7 @@ func (fx *ModelGardenServicePublisherModelTestSuiteConfig) testGet(t *testing.T)
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
+		_, err := fx.Service().GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -101,7 +103,7 @@ func (fx *ModelGardenServicePublisherModelTestSuiteConfig) testGet(t *testing.T)
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
+		_, err := fx.Service().GetPublisherModel(fx.Context(), &GetPublisherModelRequest{
 			Name: "publishers/-/models/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/model_garden_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/model_garden_service_aiptest.pb.go
@@ -12,6 +12,34 @@ import (
 	testing "testing"
 )
 
+// ModelGardenServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type ModelGardenServiceTestSuiteConfigProvider interface {
+	// ModelGardenServicePublisherModelTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	PublisherModelTestSuiteConfig(t *testing.T) *ModelGardenServicePublisherModelTestSuiteConfig
+}
+
+// TestModelGardenService is the main entrypoint for starting the AIP tests.
+func TestModelGardenService(t *testing.T, s ModelGardenServiceTestSuiteConfigProvider) {
+	testModelGardenServicePublisherModelTestSuiteConfig(t, s)
+}
+
+func testModelGardenServicePublisherModelTestSuiteConfig(t *testing.T, s ModelGardenServiceTestSuiteConfigProvider) {
+	t.Run("PublisherModel", func(t *testing.T) {
+		config := s.PublisherModelTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method PublisherModelTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method ModelGardenServicePublisherModelTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type ModelGardenServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/model_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/model_service_aiptest.pb.go
@@ -15,6 +15,72 @@ import (
 	testing "testing"
 )
 
+// ModelServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type ModelServiceTestSuiteConfigProvider interface {
+	// ModelServiceModelTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	ModelTestSuiteConfig(t *testing.T) *ModelServiceModelTestSuiteConfig
+	// ModelServiceModelEvaluationTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	ModelEvaluationTestSuiteConfig(t *testing.T) *ModelServiceModelEvaluationTestSuiteConfig
+	// ModelServiceModelEvaluationSliceTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	ModelEvaluationSliceTestSuiteConfig(t *testing.T) *ModelServiceModelEvaluationSliceTestSuiteConfig
+}
+
+// TestModelService is the main entrypoint for starting the AIP tests.
+func TestModelService(t *testing.T, s ModelServiceTestSuiteConfigProvider) {
+	testModelServiceModelTestSuiteConfig(t, s)
+	testModelServiceModelEvaluationTestSuiteConfig(t, s)
+	testModelServiceModelEvaluationSliceTestSuiteConfig(t, s)
+}
+
+func testModelServiceModelTestSuiteConfig(t *testing.T, s ModelServiceTestSuiteConfigProvider) {
+	t.Run("Model", func(t *testing.T) {
+		config := s.ModelTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method ModelTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method ModelServiceModelTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testModelServiceModelEvaluationTestSuiteConfig(t *testing.T, s ModelServiceTestSuiteConfigProvider) {
+	t.Run("ModelEvaluation", func(t *testing.T) {
+		config := s.ModelEvaluationTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method ModelEvaluationTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method ModelServiceModelEvaluationTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testModelServiceModelEvaluationSliceTestSuiteConfig(t *testing.T, s ModelServiceTestSuiteConfigProvider) {
+	t.Run("ModelEvaluationSlice", func(t *testing.T) {
+		config := s.ModelEvaluationSliceTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method ModelEvaluationSliceTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method ModelServiceModelEvaluationSliceTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type ModelServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
@@ -14,6 +14,53 @@ import (
 	time "time"
 )
 
+// PipelineServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type PipelineServiceTestSuiteConfigProvider interface {
+	// PipelineServicePipelineJobTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	PipelineJobTestSuiteConfig(t *testing.T) *PipelineServicePipelineJobTestSuiteConfig
+	// PipelineServiceTrainingPipelineTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	TrainingPipelineTestSuiteConfig(t *testing.T) *PipelineServiceTrainingPipelineTestSuiteConfig
+}
+
+// TestPipelineService is the main entrypoint for starting the AIP tests.
+func TestPipelineService(t *testing.T, s PipelineServiceTestSuiteConfigProvider) {
+	testPipelineServicePipelineJobTestSuiteConfig(t, s)
+	testPipelineServiceTrainingPipelineTestSuiteConfig(t, s)
+}
+
+func testPipelineServicePipelineJobTestSuiteConfig(t *testing.T, s PipelineServiceTestSuiteConfigProvider) {
+	t.Run("PipelineJob", func(t *testing.T) {
+		config := s.PipelineJobTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method PipelineJobTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method PipelineServicePipelineJobTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testPipelineServiceTrainingPipelineTestSuiteConfig(t *testing.T, s PipelineServiceTestSuiteConfigProvider) {
+	t.Run("TrainingPipeline", func(t *testing.T) {
+		config := s.TrainingPipelineTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method TrainingPipelineTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method PipelineServiceTrainingPipelineTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type PipelineServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
@@ -16,6 +16,34 @@ import (
 	time "time"
 )
 
+// ScheduleServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type ScheduleServiceTestSuiteConfigProvider interface {
+	// ScheduleServiceScheduleTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	ScheduleTestSuiteConfig(t *testing.T) *ScheduleServiceScheduleTestSuiteConfig
+}
+
+// TestScheduleService is the main entrypoint for starting the AIP tests.
+func TestScheduleService(t *testing.T, s ScheduleServiceTestSuiteConfigProvider) {
+	testScheduleServiceScheduleTestSuiteConfig(t, s)
+}
+
+func testScheduleServiceScheduleTestSuiteConfig(t *testing.T, s ScheduleServiceTestSuiteConfigProvider) {
+	t.Run("Schedule", func(t *testing.T) {
+		config := s.ScheduleTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method ScheduleTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method ScheduleServiceScheduleTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type ScheduleServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
@@ -25,15 +25,17 @@ type ScheduleServiceTestSuite struct {
 func (fx ScheduleServiceTestSuite) TestSchedule(ctx context.Context, options ScheduleServiceScheduleTestSuiteConfig) {
 	fx.T.Run("Schedule", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() ScheduleServiceServer { return fx.Server }
 		options.test(t)
 	})
 }
 
 type ScheduleServiceScheduleTestSuiteConfig struct {
-	service    ScheduleServiceServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() ScheduleServiceServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -68,7 +70,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+		_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 			Parent:   "",
 			Schedule: fx.Create(fx.nextParent(t, false)),
 		})
@@ -78,7 +80,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+		_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 			Parent:   "invalid resource name",
 			Schedule: fx.Create(fx.nextParent(t, false)),
 		})
@@ -90,7 +92,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		beforeCreate := time.Now()
-		msg, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+		msg, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 			Parent:   parent,
 			Schedule: fx.Create(parent),
 		})
@@ -104,12 +106,12 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+		msg, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 			Parent:   parent,
 			Schedule: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetSchedule(fx.Context(), &GetScheduleRequest{
+		persisted, err := fx.Service().GetSchedule(fx.Context(), &GetScheduleRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -130,7 +132,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("parent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+			_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 				Parent:   parent,
 				Schedule: msg,
 			})
@@ -146,7 +148,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("pipeline_job")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+			_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 				Parent:   parent,
 				Schedule: msg,
 			})
@@ -162,7 +164,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("gcs_output_directory")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+			_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 				Parent:   parent,
 				Schedule: msg,
 			})
@@ -178,7 +180,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+			_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 				Parent:   parent,
 				Schedule: msg,
 			})
@@ -194,7 +196,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+			_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 				Parent:   parent,
 				Schedule: msg,
 			})
@@ -210,7 +212,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_concurrent_run_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+			_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 				Parent:   parent,
 				Schedule: msg,
 			})
@@ -231,7 +233,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Parent = "invalid resource name"
-			_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+			_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 				Parent:   parent,
 				Schedule: msg,
 			})
@@ -246,7 +248,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Network = "invalid resource name"
-			_, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+			_, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 				Parent:   parent,
 				Schedule: msg,
 			})
@@ -261,7 +263,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSchedule(fx.Context(), &GetScheduleRequest{
+		_, err := fx.Service().GetSchedule(fx.Context(), &GetScheduleRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -270,7 +272,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSchedule(fx.Context(), &GetScheduleRequest{
+		_, err := fx.Service().GetSchedule(fx.Context(), &GetScheduleRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -281,7 +283,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetSchedule(fx.Context(), &GetScheduleRequest{
+		msg, err := fx.Service().GetSchedule(fx.Context(), &GetScheduleRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -293,7 +295,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetSchedule(fx.Context(), &GetScheduleRequest{
+		_, err := fx.Service().GetSchedule(fx.Context(), &GetScheduleRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -302,7 +304,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSchedule(fx.Context(), &GetScheduleRequest{
+		_, err := fx.Service().GetSchedule(fx.Context(), &GetScheduleRequest{
 			Name: "projects/-/locations/-/schedules/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -318,7 +320,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+		_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 			Schedule: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -330,7 +332,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+		_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 			Schedule: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -341,7 +343,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		updated, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+		updated, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 			Schedule: created,
 		})
 		assert.NilError(t, err)
@@ -353,11 +355,11 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		updated, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+		updated, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 			Schedule: created,
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetSchedule(fx.Context(), &GetScheduleRequest{
+		persisted, err := fx.Service().GetSchedule(fx.Context(), &GetScheduleRequest{
 			Name: updated.Name,
 		})
 		assert.NilError(t, err)
@@ -370,7 +372,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
 		originalCreateTime := created.CreateTime
-		updated, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+		updated, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 			Schedule: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -389,7 +391,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+		_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 			Schedule: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -398,7 +400,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+		_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 			Schedule: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -422,7 +424,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("parent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+			_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 				Schedule: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -441,7 +443,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("pipeline_job")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+			_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 				Schedule: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -460,7 +462,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("gcs_output_directory")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+			_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 				Schedule: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -479,7 +481,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("kms_key_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+			_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 				Schedule: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -498,7 +500,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+			_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 				Schedule: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -517,7 +519,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("max_concurrent_run_count")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
+			_, err := fx.Service().UpdateSchedule(fx.Context(), &UpdateScheduleRequest{
 				Schedule: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -536,7 +538,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListSchedules(fx.Context(), &ListSchedulesRequest{
+		_, err := fx.Service().ListSchedules(fx.Context(), &ListSchedulesRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -546,7 +548,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListSchedules(fx.Context(), &ListSchedulesRequest{
+		_, err := fx.Service().ListSchedules(fx.Context(), &ListSchedulesRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -557,7 +559,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListSchedules(fx.Context(), &ListSchedulesRequest{
+		_, err := fx.Service().ListSchedules(fx.Context(), &ListSchedulesRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -575,7 +577,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSchedules(fx.Context(), &ListSchedulesRequest{
+		response, err := fx.Service().ListSchedules(fx.Context(), &ListSchedulesRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -594,7 +596,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSchedules(fx.Context(), &ListSchedulesRequest{
+		response, err := fx.Service().ListSchedules(fx.Context(), &ListSchedulesRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -605,7 +607,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSchedules(fx.Context(), &ListSchedulesRequest{
+		response, err := fx.Service().ListSchedules(fx.Context(), &ListSchedulesRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -619,7 +621,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*Schedule, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListSchedules(fx.Context(), &ListSchedulesRequest{
+			response, err := fx.Service().ListSchedules(fx.Context(), &ListSchedulesRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -648,12 +650,12 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
+			_, err := fx.Service().DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListSchedules(fx.Context(), &ListSchedulesRequest{
+		response, err := fx.Service().ListSchedules(fx.Context(), &ListSchedulesRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -676,7 +678,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
+		_, err := fx.Service().DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -685,7 +687,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
+		_, err := fx.Service().DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -696,7 +698,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
+		_, err := fx.Service().DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -707,7 +709,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
+		_, err := fx.Service().DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -718,12 +720,12 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
+		deleted, err := fx.Service().DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
+		_, err = fx.Service().DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -732,7 +734,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
+		_, err := fx.Service().DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
 			Name: "projects/-/locations/-/schedules/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -768,7 +770,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) maybeSkip(t *testing.T) {
 
 func (fx *ScheduleServiceScheduleTestSuiteConfig) create(t *testing.T, parent string) *Schedule {
 	t.Helper()
-	created, err := fx.service.CreateSchedule(fx.Context(), &CreateScheduleRequest{
+	created, err := fx.Service().CreateSchedule(fx.Context(), &CreateScheduleRequest{
 		Parent:   parent,
 		Schedule: fx.Create(parent),
 	})

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/specialist_pool_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/specialist_pool_service_aiptest.pb.go
@@ -24,15 +24,17 @@ type SpecialistPoolServiceTestSuite struct {
 func (fx SpecialistPoolServiceTestSuite) TestSpecialistPool(ctx context.Context, options SpecialistPoolServiceSpecialistPoolTestSuiteConfig) {
 	fx.T.Run("SpecialistPool", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() SpecialistPoolServiceServer { return fx.Server }
 		options.test(t)
 	})
 }
 
 type SpecialistPoolServiceSpecialistPoolTestSuiteConfig struct {
-	service    SpecialistPoolServiceServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() SpecialistPoolServiceServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -67,7 +69,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testCreate(t *test
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
+		_, err := fx.Service().CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
 			Parent:         "",
 			SpecialistPool: fx.Create(fx.nextParent(t, false)),
 		})
@@ -77,7 +79,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testCreate(t *test
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
+		_, err := fx.Service().CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
 			Parent:         "invalid resource name",
 			SpecialistPool: fx.Create(fx.nextParent(t, false)),
 		})
@@ -98,7 +100,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testCreate(t *test
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
+			_, err := fx.Service().CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
 				Parent:         parent,
 				SpecialistPool: msg,
 			})
@@ -114,7 +116,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testCreate(t *test
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
+			_, err := fx.Service().CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
 				Parent:         parent,
 				SpecialistPool: msg,
 			})
@@ -129,7 +131,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
+		_, err := fx.Service().GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -138,7 +140,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
+		_, err := fx.Service().GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -149,7 +151,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
+		msg, err := fx.Service().GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -161,7 +163,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
+		_, err := fx.Service().GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -170,7 +172,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
+		_, err := fx.Service().GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: "projects/-/locations/-/specialistPools/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -186,7 +188,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
+		_, err := fx.Service().UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 			SpecialistPool: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -198,7 +200,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
+		_, err := fx.Service().UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 			SpecialistPool: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -211,7 +213,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
+		_, err := fx.Service().UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 			SpecialistPool: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -220,7 +222,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
+		_, err := fx.Service().UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 			SpecialistPool: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -244,7 +246,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
+			_, err := fx.Service().UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 				SpecialistPool: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -263,7 +265,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
+			_, err := fx.Service().UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 				SpecialistPool: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -282,7 +284,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
+		_, err := fx.Service().ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -292,7 +294,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
+		_, err := fx.Service().ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -303,7 +305,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
+		_, err := fx.Service().ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -321,7 +323,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
+		response, err := fx.Service().ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -340,7 +342,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
+		response, err := fx.Service().ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -351,7 +353,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
+		response, err := fx.Service().ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -365,7 +367,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 		msgs := make([]*SpecialistPool, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
+			response, err := fx.Service().ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -394,12 +396,12 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
+			_, err := fx.Service().DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
+		response, err := fx.Service().ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -422,7 +424,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
+		_, err := fx.Service().DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -431,7 +433,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
+		_, err := fx.Service().DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -442,7 +444,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
+		_, err := fx.Service().DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -453,7 +455,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
+		_, err := fx.Service().DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -464,12 +466,12 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
+		deleted, err := fx.Service().DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
+		_, err = fx.Service().DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -478,7 +480,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
+		_, err := fx.Service().DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: "projects/-/locations/-/specialistPools/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/specialist_pool_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/specialist_pool_service_aiptest.pb.go
@@ -23,17 +23,19 @@ type SpecialistPoolServiceTestSuite struct {
 
 func (fx SpecialistPoolServiceTestSuite) TestSpecialistPool(ctx context.Context, options SpecialistPoolServiceSpecialistPoolTestSuiteConfig) {
 	fx.T.Run("SpecialistPool", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
 }
 
 type SpecialistPoolServiceSpecialistPoolTestSuiteConfig struct {
-	ctx        context.Context
 	service    SpecialistPoolServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -65,7 +67,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testCreate(t *test
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateSpecialistPool(fx.ctx, &CreateSpecialistPoolRequest{
+		_, err := fx.service.CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
 			Parent:         "",
 			SpecialistPool: fx.Create(fx.nextParent(t, false)),
 		})
@@ -75,7 +77,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testCreate(t *test
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateSpecialistPool(fx.ctx, &CreateSpecialistPoolRequest{
+		_, err := fx.service.CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
 			Parent:         "invalid resource name",
 			SpecialistPool: fx.Create(fx.nextParent(t, false)),
 		})
@@ -96,7 +98,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testCreate(t *test
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSpecialistPool(fx.ctx, &CreateSpecialistPoolRequest{
+			_, err := fx.service.CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
 				Parent:         parent,
 				SpecialistPool: msg,
 			})
@@ -112,7 +114,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testCreate(t *test
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSpecialistPool(fx.ctx, &CreateSpecialistPoolRequest{
+			_, err := fx.service.CreateSpecialistPool(fx.Context(), &CreateSpecialistPoolRequest{
 				Parent:         parent,
 				SpecialistPool: msg,
 			})
@@ -127,7 +129,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSpecialistPool(fx.ctx, &GetSpecialistPoolRequest{
+		_, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -136,7 +138,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSpecialistPool(fx.ctx, &GetSpecialistPoolRequest{
+		_, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -147,7 +149,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetSpecialistPool(fx.ctx, &GetSpecialistPoolRequest{
+		msg, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -159,7 +161,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetSpecialistPool(fx.ctx, &GetSpecialistPoolRequest{
+		_, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -168,7 +170,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testGet(t *testing
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSpecialistPool(fx.ctx, &GetSpecialistPoolRequest{
+		_, err := fx.service.GetSpecialistPool(fx.Context(), &GetSpecialistPoolRequest{
 			Name: "projects/-/locations/-/specialistPools/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -184,7 +186,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateSpecialistPool(fx.ctx, &UpdateSpecialistPoolRequest{
+		_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 			SpecialistPool: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -196,7 +198,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateSpecialistPool(fx.ctx, &UpdateSpecialistPoolRequest{
+		_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 			SpecialistPool: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -209,7 +211,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateSpecialistPool(fx.ctx, &UpdateSpecialistPoolRequest{
+		_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 			SpecialistPool: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -218,7 +220,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateSpecialistPool(fx.ctx, &UpdateSpecialistPoolRequest{
+		_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 			SpecialistPool: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -242,7 +244,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSpecialistPool(fx.ctx, &UpdateSpecialistPoolRequest{
+			_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 				SpecialistPool: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -261,7 +263,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testUpdate(t *test
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSpecialistPool(fx.ctx, &UpdateSpecialistPoolRequest{
+			_, err := fx.service.UpdateSpecialistPool(fx.Context(), &UpdateSpecialistPoolRequest{
 				SpecialistPool: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -280,7 +282,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListSpecialistPools(fx.ctx, &ListSpecialistPoolsRequest{
+		_, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -290,7 +292,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListSpecialistPools(fx.ctx, &ListSpecialistPoolsRequest{
+		_, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -301,7 +303,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListSpecialistPools(fx.ctx, &ListSpecialistPoolsRequest{
+		_, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -319,7 +321,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSpecialistPools(fx.ctx, &ListSpecialistPoolsRequest{
+		response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -338,7 +340,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSpecialistPools(fx.ctx, &ListSpecialistPoolsRequest{
+		response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -349,7 +351,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSpecialistPools(fx.ctx, &ListSpecialistPoolsRequest{
+		response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -363,7 +365,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 		msgs := make([]*SpecialistPool, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListSpecialistPools(fx.ctx, &ListSpecialistPoolsRequest{
+			response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -392,12 +394,12 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteSpecialistPool(fx.ctx, &DeleteSpecialistPoolRequest{
+			_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListSpecialistPools(fx.ctx, &ListSpecialistPoolsRequest{
+		response, err := fx.service.ListSpecialistPools(fx.Context(), &ListSpecialistPoolsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -420,7 +422,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSpecialistPool(fx.ctx, &DeleteSpecialistPoolRequest{
+		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -429,7 +431,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSpecialistPool(fx.ctx, &DeleteSpecialistPoolRequest{
+		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -440,7 +442,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteSpecialistPool(fx.ctx, &DeleteSpecialistPoolRequest{
+		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -451,7 +453,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteSpecialistPool(fx.ctx, &DeleteSpecialistPoolRequest{
+		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -462,12 +464,12 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteSpecialistPool(fx.ctx, &DeleteSpecialistPoolRequest{
+		deleted, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteSpecialistPool(fx.ctx, &DeleteSpecialistPoolRequest{
+		_, err = fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -476,7 +478,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testDelete(t *test
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSpecialistPool(fx.ctx, &DeleteSpecialistPoolRequest{
+		_, err := fx.service.DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 			Name: "projects/-/locations/-/specialistPools/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/specialist_pool_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/specialist_pool_service_aiptest.pb.go
@@ -15,6 +15,34 @@ import (
 	testing "testing"
 )
 
+// SpecialistPoolServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type SpecialistPoolServiceTestSuiteConfigProvider interface {
+	// SpecialistPoolServiceSpecialistPoolTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	SpecialistPoolTestSuiteConfig(t *testing.T) *SpecialistPoolServiceSpecialistPoolTestSuiteConfig
+}
+
+// TestSpecialistPoolService is the main entrypoint for starting the AIP tests.
+func TestSpecialistPoolService(t *testing.T, s SpecialistPoolServiceTestSuiteConfigProvider) {
+	testSpecialistPoolServiceSpecialistPoolTestSuiteConfig(t, s)
+}
+
+func testSpecialistPoolServiceSpecialistPoolTestSuiteConfig(t *testing.T, s SpecialistPoolServiceTestSuiteConfigProvider) {
+	t.Run("SpecialistPool", func(t *testing.T) {
+		config := s.SpecialistPoolTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method SpecialistPoolTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method SpecialistPoolServiceSpecialistPoolTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type SpecialistPoolServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
@@ -16,6 +16,91 @@ import (
 	time "time"
 )
 
+// TensorboardServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type TensorboardServiceTestSuiteConfigProvider interface {
+	// TensorboardServiceTensorboardTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	TensorboardTestSuiteConfig(t *testing.T) *TensorboardServiceTensorboardTestSuiteConfig
+	// TensorboardServiceTensorboardExperimentTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	TensorboardExperimentTestSuiteConfig(t *testing.T) *TensorboardServiceTensorboardExperimentTestSuiteConfig
+	// TensorboardServiceTensorboardRunTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	TensorboardRunTestSuiteConfig(t *testing.T) *TensorboardServiceTensorboardRunTestSuiteConfig
+	// TensorboardServiceTensorboardTimeSeriesTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	TensorboardTimeSeriesTestSuiteConfig(t *testing.T) *TensorboardServiceTensorboardTimeSeriesTestSuiteConfig
+}
+
+// TestTensorboardService is the main entrypoint for starting the AIP tests.
+func TestTensorboardService(t *testing.T, s TensorboardServiceTestSuiteConfigProvider) {
+	testTensorboardServiceTensorboardTestSuiteConfig(t, s)
+	testTensorboardServiceTensorboardExperimentTestSuiteConfig(t, s)
+	testTensorboardServiceTensorboardRunTestSuiteConfig(t, s)
+	testTensorboardServiceTensorboardTimeSeriesTestSuiteConfig(t, s)
+}
+
+func testTensorboardServiceTensorboardTestSuiteConfig(t *testing.T, s TensorboardServiceTestSuiteConfigProvider) {
+	t.Run("Tensorboard", func(t *testing.T) {
+		config := s.TensorboardTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method TensorboardTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method TensorboardServiceTensorboardTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testTensorboardServiceTensorboardExperimentTestSuiteConfig(t *testing.T, s TensorboardServiceTestSuiteConfigProvider) {
+	t.Run("TensorboardExperiment", func(t *testing.T) {
+		config := s.TensorboardExperimentTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method TensorboardExperimentTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method TensorboardServiceTensorboardExperimentTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testTensorboardServiceTensorboardRunTestSuiteConfig(t *testing.T, s TensorboardServiceTestSuiteConfigProvider) {
+	t.Run("TensorboardRun", func(t *testing.T) {
+		config := s.TensorboardRunTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method TensorboardRunTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method TensorboardServiceTensorboardRunTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testTensorboardServiceTensorboardTimeSeriesTestSuiteConfig(t *testing.T, s TensorboardServiceTestSuiteConfigProvider) {
+	t.Run("TensorboardTimeSeries", func(t *testing.T) {
+		config := s.TensorboardTimeSeriesTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method TensorboardTimeSeriesTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method TensorboardServiceTensorboardTimeSeriesTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type TensorboardServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
@@ -14,6 +14,53 @@ import (
 	time "time"
 )
 
+// VizierServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type VizierServiceTestSuiteConfigProvider interface {
+	// VizierServiceStudyTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	StudyTestSuiteConfig(t *testing.T) *VizierServiceStudyTestSuiteConfig
+	// VizierServiceTrialTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	TrialTestSuiteConfig(t *testing.T) *VizierServiceTrialTestSuiteConfig
+}
+
+// TestVizierService is the main entrypoint for starting the AIP tests.
+func TestVizierService(t *testing.T, s VizierServiceTestSuiteConfigProvider) {
+	testVizierServiceStudyTestSuiteConfig(t, s)
+	testVizierServiceTrialTestSuiteConfig(t, s)
+}
+
+func testVizierServiceStudyTestSuiteConfig(t *testing.T, s VizierServiceTestSuiteConfigProvider) {
+	t.Run("Study", func(t *testing.T) {
+		config := s.StudyTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method StudyTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method VizierServiceStudyTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testVizierServiceTrialTestSuiteConfig(t *testing.T, s VizierServiceTestSuiteConfigProvider) {
+	t.Run("Trial", func(t *testing.T) {
+		config := s.TrialTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method TrialTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method VizierServiceTrialTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type VizierServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/area120/tables/apiv1alpha1/tablespb/tables_aiptest.pb.go
+++ b/proto/gen/googleapis/area120/tables/apiv1alpha1/tablespb/tables_aiptest.pb.go
@@ -22,7 +22,7 @@ type TablesServiceTestSuite struct {
 
 func (fx TablesServiceTestSuite) TestRow(ctx context.Context, options TablesServiceRowTestSuiteConfig) {
 	fx.T.Run("Row", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -30,7 +30,7 @@ func (fx TablesServiceTestSuite) TestRow(ctx context.Context, options TablesServ
 
 func (fx TablesServiceTestSuite) TestTable(ctx context.Context, options TablesServiceTableTestSuiteConfig) {
 	fx.T.Run("Table", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -38,17 +38,19 @@ func (fx TablesServiceTestSuite) TestTable(ctx context.Context, options TablesSe
 
 func (fx TablesServiceTestSuite) TestWorkspace(ctx context.Context, options TablesServiceWorkspaceTestSuiteConfig) {
 	fx.T.Run("Workspace", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
 }
 
 type TablesServiceRowTestSuiteConfig struct {
-	ctx        context.Context
 	service    TablesServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -80,7 +82,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateRow(fx.ctx, &CreateRowRequest{
+		_, err := fx.service.CreateRow(fx.Context(), &CreateRowRequest{
 			Parent: "",
 			Row:    fx.Create(fx.nextParent(t, false)),
 		})
@@ -90,7 +92,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateRow(fx.ctx, &CreateRowRequest{
+		_, err := fx.service.CreateRow(fx.Context(), &CreateRowRequest{
 			Parent: "invalid resource name",
 			Row:    fx.Create(fx.nextParent(t, false)),
 		})
@@ -101,12 +103,12 @@ func (fx *TablesServiceRowTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateRow(fx.ctx, &CreateRowRequest{
+		msg, err := fx.service.CreateRow(fx.Context(), &CreateRowRequest{
 			Parent: parent,
 			Row:    fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetRow(fx.ctx, &GetRowRequest{
+		persisted, err := fx.service.GetRow(fx.Context(), &GetRowRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -120,7 +122,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetRow(fx.ctx, &GetRowRequest{
+		_, err := fx.service.GetRow(fx.Context(), &GetRowRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -129,7 +131,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetRow(fx.ctx, &GetRowRequest{
+		_, err := fx.service.GetRow(fx.Context(), &GetRowRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -140,7 +142,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetRow(fx.ctx, &GetRowRequest{
+		msg, err := fx.service.GetRow(fx.Context(), &GetRowRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -152,7 +154,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetRow(fx.ctx, &GetRowRequest{
+		_, err := fx.service.GetRow(fx.Context(), &GetRowRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -161,7 +163,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetRow(fx.ctx, &GetRowRequest{
+		_, err := fx.service.GetRow(fx.Context(), &GetRowRequest{
 			Name: "tables/-/rows/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -177,7 +179,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateRow(fx.ctx, &UpdateRowRequest{
+		_, err := fx.service.UpdateRow(fx.Context(), &UpdateRowRequest{
 			Row: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -189,7 +191,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateRow(fx.ctx, &UpdateRowRequest{
+		_, err := fx.service.UpdateRow(fx.Context(), &UpdateRowRequest{
 			Row: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -200,11 +202,11 @@ func (fx *TablesServiceRowTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		updated, err := fx.service.UpdateRow(fx.ctx, &UpdateRowRequest{
+		updated, err := fx.service.UpdateRow(fx.Context(), &UpdateRowRequest{
 			Row: created,
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetRow(fx.ctx, &GetRowRequest{
+		persisted, err := fx.service.GetRow(fx.Context(), &GetRowRequest{
 			Name: updated.Name,
 		})
 		assert.NilError(t, err)
@@ -218,7 +220,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateRow(fx.ctx, &UpdateRowRequest{
+		_, err := fx.service.UpdateRow(fx.Context(), &UpdateRowRequest{
 			Row: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -227,7 +229,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateRow(fx.ctx, &UpdateRowRequest{
+		_, err := fx.service.UpdateRow(fx.Context(), &UpdateRowRequest{
 			Row: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -245,7 +247,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListRows(fx.ctx, &ListRowsRequest{
+		_, err := fx.service.ListRows(fx.Context(), &ListRowsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -255,7 +257,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListRows(fx.ctx, &ListRowsRequest{
+		_, err := fx.service.ListRows(fx.Context(), &ListRowsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -266,7 +268,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListRows(fx.ctx, &ListRowsRequest{
+		_, err := fx.service.ListRows(fx.Context(), &ListRowsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -284,7 +286,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListRows(fx.ctx, &ListRowsRequest{
+		response, err := fx.service.ListRows(fx.Context(), &ListRowsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -303,7 +305,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListRows(fx.ctx, &ListRowsRequest{
+		response, err := fx.service.ListRows(fx.Context(), &ListRowsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -314,7 +316,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListRows(fx.ctx, &ListRowsRequest{
+		response, err := fx.service.ListRows(fx.Context(), &ListRowsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -328,7 +330,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*Row, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListRows(fx.ctx, &ListRowsRequest{
+			response, err := fx.service.ListRows(fx.Context(), &ListRowsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -357,12 +359,12 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteRow(fx.ctx, &DeleteRowRequest{
+			_, err := fx.service.DeleteRow(fx.Context(), &DeleteRowRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListRows(fx.ctx, &ListRowsRequest{
+		response, err := fx.service.ListRows(fx.Context(), &ListRowsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -385,7 +387,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteRow(fx.ctx, &DeleteRowRequest{
+		_, err := fx.service.DeleteRow(fx.Context(), &DeleteRowRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -394,7 +396,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteRow(fx.ctx, &DeleteRowRequest{
+		_, err := fx.service.DeleteRow(fx.Context(), &DeleteRowRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -405,7 +407,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteRow(fx.ctx, &DeleteRowRequest{
+		_, err := fx.service.DeleteRow(fx.Context(), &DeleteRowRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -416,7 +418,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteRow(fx.ctx, &DeleteRowRequest{
+		_, err := fx.service.DeleteRow(fx.Context(), &DeleteRowRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -427,12 +429,12 @@ func (fx *TablesServiceRowTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteRow(fx.ctx, &DeleteRowRequest{
+		deleted, err := fx.service.DeleteRow(fx.Context(), &DeleteRowRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteRow(fx.ctx, &DeleteRowRequest{
+		_, err = fx.service.DeleteRow(fx.Context(), &DeleteRowRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -441,7 +443,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteRow(fx.ctx, &DeleteRowRequest{
+		_, err := fx.service.DeleteRow(fx.Context(), &DeleteRowRequest{
 			Name: "tables/-/rows/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -477,7 +479,7 @@ func (fx *TablesServiceRowTestSuiteConfig) maybeSkip(t *testing.T) {
 
 func (fx *TablesServiceRowTestSuiteConfig) create(t *testing.T, parent string) *Row {
 	t.Helper()
-	created, err := fx.service.CreateRow(fx.ctx, &CreateRowRequest{
+	created, err := fx.service.CreateRow(fx.Context(), &CreateRowRequest{
 		Parent: parent,
 		Row:    fx.Create(parent),
 	})
@@ -486,10 +488,12 @@ func (fx *TablesServiceRowTestSuiteConfig) create(t *testing.T, parent string) *
 }
 
 type TablesServiceTableTestSuiteConfig struct {
-	ctx        context.Context
 	service    TablesServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// CreateResource should create a Table and return it.
 	// If the field is not set, some tests will be skipped.
 	//
@@ -513,7 +517,7 @@ func (fx *TablesServiceTableTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetTable(fx.ctx, &GetTableRequest{
+		_, err := fx.service.GetTable(fx.Context(), &GetTableRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -522,7 +526,7 @@ func (fx *TablesServiceTableTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetTable(fx.ctx, &GetTableRequest{
+		_, err := fx.service.GetTable(fx.Context(), &GetTableRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -532,7 +536,7 @@ func (fx *TablesServiceTableTestSuiteConfig) testGet(t *testing.T) {
 	t.Run("exists", func(t *testing.T) {
 		fx.maybeSkip(t)
 		created := fx.create(t)
-		msg, err := fx.service.GetTable(fx.ctx, &GetTableRequest{
+		msg, err := fx.service.GetTable(fx.Context(), &GetTableRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -543,7 +547,7 @@ func (fx *TablesServiceTableTestSuiteConfig) testGet(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		fx.maybeSkip(t)
 		created := fx.create(t)
-		_, err := fx.service.GetTable(fx.ctx, &GetTableRequest{
+		_, err := fx.service.GetTable(fx.Context(), &GetTableRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -552,7 +556,7 @@ func (fx *TablesServiceTableTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetTable(fx.ctx, &GetTableRequest{
+		_, err := fx.service.GetTable(fx.Context(), &GetTableRequest{
 			Name: "tables/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -565,7 +569,7 @@ func (fx *TablesServiceTableTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument is provided page token is not valid.
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListTables(fx.ctx, &ListTablesRequest{
+		_, err := fx.service.ListTables(fx.Context(), &ListTablesRequest{
 			PageToken: "invalid page token",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -574,7 +578,7 @@ func (fx *TablesServiceTableTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument is provided page size is negative.
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListTables(fx.ctx, &ListTablesRequest{
+		_, err := fx.service.ListTables(fx.Context(), &ListTablesRequest{
 			PageSize: -10,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -595,16 +599,18 @@ func (fx *TablesServiceTableTestSuiteConfig) create(t *testing.T) *Table {
 	if fx.CreateResource == nil {
 		t.Skip("Test skipped because CreateResource not specified on TablesServiceTableTestSuiteConfig")
 	}
-	created, err := fx.CreateResource(fx.ctx)
+	created, err := fx.CreateResource(fx.Context())
 	assert.NilError(t, err)
 	return created
 }
 
 type TablesServiceWorkspaceTestSuiteConfig struct {
-	ctx        context.Context
 	service    TablesServiceServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// CreateResource should create a Workspace and return it.
 	// If the field is not set, some tests will be skipped.
 	//
@@ -628,7 +634,7 @@ func (fx *TablesServiceWorkspaceTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetWorkspace(fx.ctx, &GetWorkspaceRequest{
+		_, err := fx.service.GetWorkspace(fx.Context(), &GetWorkspaceRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -637,7 +643,7 @@ func (fx *TablesServiceWorkspaceTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetWorkspace(fx.ctx, &GetWorkspaceRequest{
+		_, err := fx.service.GetWorkspace(fx.Context(), &GetWorkspaceRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -647,7 +653,7 @@ func (fx *TablesServiceWorkspaceTestSuiteConfig) testGet(t *testing.T) {
 	t.Run("exists", func(t *testing.T) {
 		fx.maybeSkip(t)
 		created := fx.create(t)
-		msg, err := fx.service.GetWorkspace(fx.ctx, &GetWorkspaceRequest{
+		msg, err := fx.service.GetWorkspace(fx.Context(), &GetWorkspaceRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -658,7 +664,7 @@ func (fx *TablesServiceWorkspaceTestSuiteConfig) testGet(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		fx.maybeSkip(t)
 		created := fx.create(t)
-		_, err := fx.service.GetWorkspace(fx.ctx, &GetWorkspaceRequest{
+		_, err := fx.service.GetWorkspace(fx.Context(), &GetWorkspaceRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -667,7 +673,7 @@ func (fx *TablesServiceWorkspaceTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetWorkspace(fx.ctx, &GetWorkspaceRequest{
+		_, err := fx.service.GetWorkspace(fx.Context(), &GetWorkspaceRequest{
 			Name: "workspaces/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -680,7 +686,7 @@ func (fx *TablesServiceWorkspaceTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument is provided page token is not valid.
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListWorkspaces(fx.ctx, &ListWorkspacesRequest{
+		_, err := fx.service.ListWorkspaces(fx.Context(), &ListWorkspacesRequest{
 			PageToken: "invalid page token",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -689,7 +695,7 @@ func (fx *TablesServiceWorkspaceTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument is provided page size is negative.
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListWorkspaces(fx.ctx, &ListWorkspacesRequest{
+		_, err := fx.service.ListWorkspaces(fx.Context(), &ListWorkspacesRequest{
 			PageSize: -10,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -710,7 +716,7 @@ func (fx *TablesServiceWorkspaceTestSuiteConfig) create(t *testing.T) *Workspace
 	if fx.CreateResource == nil {
 		t.Skip("Test skipped because CreateResource not specified on TablesServiceWorkspaceTestSuiteConfig")
 	}
-	created, err := fx.CreateResource(fx.ctx)
+	created, err := fx.CreateResource(fx.Context())
 	assert.NilError(t, err)
 	return created
 }

--- a/proto/gen/googleapis/area120/tables/apiv1alpha1/tablespb/tables_aiptest.pb.go
+++ b/proto/gen/googleapis/area120/tables/apiv1alpha1/tablespb/tables_aiptest.pb.go
@@ -14,6 +14,72 @@ import (
 	testing "testing"
 )
 
+// TablesServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type TablesServiceTestSuiteConfigProvider interface {
+	// TablesServiceRowTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	RowTestSuiteConfig(t *testing.T) *TablesServiceRowTestSuiteConfig
+	// TablesServiceTableTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	TableTestSuiteConfig(t *testing.T) *TablesServiceTableTestSuiteConfig
+	// TablesServiceWorkspaceTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	WorkspaceTestSuiteConfig(t *testing.T) *TablesServiceWorkspaceTestSuiteConfig
+}
+
+// TestTablesService is the main entrypoint for starting the AIP tests.
+func TestTablesService(t *testing.T, s TablesServiceTestSuiteConfigProvider) {
+	testTablesServiceRowTestSuiteConfig(t, s)
+	testTablesServiceTableTestSuiteConfig(t, s)
+	testTablesServiceWorkspaceTestSuiteConfig(t, s)
+}
+
+func testTablesServiceRowTestSuiteConfig(t *testing.T, s TablesServiceTestSuiteConfigProvider) {
+	t.Run("Row", func(t *testing.T) {
+		config := s.RowTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method RowTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method TablesServiceRowTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testTablesServiceTableTestSuiteConfig(t *testing.T, s TablesServiceTestSuiteConfigProvider) {
+	t.Run("Table", func(t *testing.T) {
+		config := s.TableTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method TableTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method TablesServiceTableTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testTablesServiceWorkspaceTestSuiteConfig(t *testing.T, s TablesServiceTestSuiteConfigProvider) {
+	t.Run("Workspace", func(t *testing.T) {
+		config := s.WorkspaceTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method WorkspaceTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method TablesServiceWorkspaceTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type TablesServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/gsuiteaddons/apiv1/gsuiteaddonspb/gsuiteaddons_aiptest.pb.go
+++ b/proto/gen/googleapis/gsuiteaddons/apiv1/gsuiteaddonspb/gsuiteaddons_aiptest.pb.go
@@ -13,6 +13,72 @@ import (
 	testing "testing"
 )
 
+// GSuiteAddOnsTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type GSuiteAddOnsTestSuiteConfigProvider interface {
+	// GSuiteAddOnsAuthorizationTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	AuthorizationTestSuiteConfig(t *testing.T) *GSuiteAddOnsAuthorizationTestSuiteConfig
+	// GSuiteAddOnsDeploymentTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	DeploymentTestSuiteConfig(t *testing.T) *GSuiteAddOnsDeploymentTestSuiteConfig
+	// GSuiteAddOnsInstallStatusTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	InstallStatusTestSuiteConfig(t *testing.T) *GSuiteAddOnsInstallStatusTestSuiteConfig
+}
+
+// TestGSuiteAddOns is the main entrypoint for starting the AIP tests.
+func TestGSuiteAddOns(t *testing.T, s GSuiteAddOnsTestSuiteConfigProvider) {
+	testGSuiteAddOnsAuthorizationTestSuiteConfig(t, s)
+	testGSuiteAddOnsDeploymentTestSuiteConfig(t, s)
+	testGSuiteAddOnsInstallStatusTestSuiteConfig(t, s)
+}
+
+func testGSuiteAddOnsAuthorizationTestSuiteConfig(t *testing.T, s GSuiteAddOnsTestSuiteConfigProvider) {
+	t.Run("Authorization", func(t *testing.T) {
+		config := s.AuthorizationTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method AuthorizationTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method GSuiteAddOnsAuthorizationTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testGSuiteAddOnsDeploymentTestSuiteConfig(t *testing.T, s GSuiteAddOnsTestSuiteConfigProvider) {
+	t.Run("Deployment", func(t *testing.T) {
+		config := s.DeploymentTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method DeploymentTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method GSuiteAddOnsDeploymentTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testGSuiteAddOnsInstallStatusTestSuiteConfig(t *testing.T, s GSuiteAddOnsTestSuiteConfigProvider) {
+	t.Run("InstallStatus", func(t *testing.T) {
+		config := s.InstallStatusTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method InstallStatusTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method GSuiteAddOnsInstallStatusTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type GSuiteAddOnsTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/pubsub/apiv1/pubsubpb/pubsub_aiptest.pb.go
+++ b/proto/gen/googleapis/pubsub/apiv1/pubsubpb/pubsub_aiptest.pb.go
@@ -13,6 +13,34 @@ import (
 	testing "testing"
 )
 
+// PublisherTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type PublisherTestSuiteConfigProvider interface {
+	// PublisherTopicTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	TopicTestSuiteConfig(t *testing.T) *PublisherTopicTestSuiteConfig
+}
+
+// TestPublisher is the main entrypoint for starting the AIP tests.
+func TestPublisher(t *testing.T, s PublisherTestSuiteConfigProvider) {
+	testPublisherTopicTestSuiteConfig(t, s)
+}
+
+func testPublisherTopicTestSuiteConfig(t *testing.T, s PublisherTestSuiteConfigProvider) {
+	t.Run("Topic", func(t *testing.T) {
+		config := s.TopicTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method TopicTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method PublisherTopicTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type PublisherTestSuite struct {
 	T *testing.T
 	// Server to test.
@@ -270,6 +298,53 @@ func (fx *PublisherTopicTestSuiteConfig) create(t *testing.T, parent string) *To
 	created, err := fx.CreateResource(fx.Context(), parent)
 	assert.NilError(t, err)
 	return created
+}
+
+// SubscriberTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type SubscriberTestSuiteConfigProvider interface {
+	// SubscriberSnapshotTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	SnapshotTestSuiteConfig(t *testing.T) *SubscriberSnapshotTestSuiteConfig
+	// SubscriberSubscriptionTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	SubscriptionTestSuiteConfig(t *testing.T) *SubscriberSubscriptionTestSuiteConfig
+}
+
+// TestSubscriber is the main entrypoint for starting the AIP tests.
+func TestSubscriber(t *testing.T, s SubscriberTestSuiteConfigProvider) {
+	testSubscriberSnapshotTestSuiteConfig(t, s)
+	testSubscriberSubscriptionTestSuiteConfig(t, s)
+}
+
+func testSubscriberSnapshotTestSuiteConfig(t *testing.T, s SubscriberTestSuiteConfigProvider) {
+	t.Run("Snapshot", func(t *testing.T) {
+		config := s.SnapshotTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method SnapshotTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method SubscriberSnapshotTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testSubscriberSubscriptionTestSuiteConfig(t *testing.T, s SubscriberTestSuiteConfigProvider) {
+	t.Run("Subscription", func(t *testing.T) {
+		config := s.SubscriptionTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method SubscriptionTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method SubscriberSubscriptionTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
 }
 
 type SubscriberTestSuite struct {

--- a/proto/gen/googleapis/pubsub/apiv1/pubsubpb/pubsub_aiptest.pb.go
+++ b/proto/gen/googleapis/pubsub/apiv1/pubsubpb/pubsub_aiptest.pb.go
@@ -22,15 +22,17 @@ type PublisherTestSuite struct {
 func (fx PublisherTestSuite) TestTopic(ctx context.Context, options PublisherTopicTestSuiteConfig) {
 	fx.T.Run("Topic", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() PublisherServer { return fx.Server }
 		options.test(t)
 	})
 }
 
 type PublisherTopicTestSuiteConfig struct {
-	service    PublisherServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() PublisherServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -67,7 +69,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+		_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 			Topic: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -79,7 +81,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+		_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 			Topic: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -92,7 +94,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+		_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 			Topic: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -101,7 +103,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+		_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 			Topic: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -125,7 +127,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+			_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 				Topic: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -144,7 +146,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("schema")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+			_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 				Topic: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -163,7 +165,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("stream_arn")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+			_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 				Topic: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -182,7 +184,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("consumer_arn")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+			_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 				Topic: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -201,7 +203,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("aws_role_arn")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+			_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 				Topic: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -220,7 +222,7 @@ func (fx *PublisherTopicTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("gcp_service_account")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateTopic(fx.Context(), &UpdateTopicRequest{
+			_, err := fx.Service().UpdateTopic(fx.Context(), &UpdateTopicRequest{
 				Topic: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -279,7 +281,7 @@ type SubscriberTestSuite struct {
 func (fx SubscriberTestSuite) TestSnapshot(ctx context.Context, options SubscriberSnapshotTestSuiteConfig) {
 	fx.T.Run("Snapshot", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() SubscriberServer { return fx.Server }
 		options.test(t)
 	})
 }
@@ -287,15 +289,17 @@ func (fx SubscriberTestSuite) TestSnapshot(ctx context.Context, options Subscrib
 func (fx SubscriberTestSuite) TestSubscription(ctx context.Context, options SubscriberSubscriptionTestSuiteConfig) {
 	fx.T.Run("Subscription", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() SubscriberServer { return fx.Server }
 		options.test(t)
 	})
 }
 
 type SubscriberSnapshotTestSuiteConfig struct {
-	service    SubscriberServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() SubscriberServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -332,7 +336,7 @@ func (fx *SubscriberSnapshotTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateSnapshot(fx.Context(), &UpdateSnapshotRequest{
+		_, err := fx.Service().UpdateSnapshot(fx.Context(), &UpdateSnapshotRequest{
 			Snapshot: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -344,7 +348,7 @@ func (fx *SubscriberSnapshotTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateSnapshot(fx.Context(), &UpdateSnapshotRequest{
+		_, err := fx.Service().UpdateSnapshot(fx.Context(), &UpdateSnapshotRequest{
 			Snapshot: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -357,7 +361,7 @@ func (fx *SubscriberSnapshotTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateSnapshot(fx.Context(), &UpdateSnapshotRequest{
+		_, err := fx.Service().UpdateSnapshot(fx.Context(), &UpdateSnapshotRequest{
 			Snapshot: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -366,7 +370,7 @@ func (fx *SubscriberSnapshotTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateSnapshot(fx.Context(), &UpdateSnapshotRequest{
+		_, err := fx.Service().UpdateSnapshot(fx.Context(), &UpdateSnapshotRequest{
 			Snapshot: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -416,9 +420,11 @@ func (fx *SubscriberSnapshotTestSuiteConfig) create(t *testing.T, parent string)
 }
 
 type SubscriberSubscriptionTestSuiteConfig struct {
-	service    SubscriberServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() SubscriberServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -455,7 +461,7 @@ func (fx *SubscriberSubscriptionTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
+		_, err := fx.Service().UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
 			Subscription: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -467,7 +473,7 @@ func (fx *SubscriberSubscriptionTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
+		_, err := fx.Service().UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
 			Subscription: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -480,7 +486,7 @@ func (fx *SubscriberSubscriptionTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
+		_, err := fx.Service().UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
 			Subscription: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -489,7 +495,7 @@ func (fx *SubscriberSubscriptionTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
+		_, err := fx.Service().UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
 			Subscription: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -513,7 +519,7 @@ func (fx *SubscriberSubscriptionTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
+			_, err := fx.Service().UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
 				Subscription: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -532,7 +538,7 @@ func (fx *SubscriberSubscriptionTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("topic")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
+			_, err := fx.Service().UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
 				Subscription: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{
@@ -551,7 +557,7 @@ func (fx *SubscriberSubscriptionTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("bucket")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
+			_, err := fx.Service().UpdateSubscription(fx.Context(), &UpdateSubscriptionRequest{
 				Subscription: msg,
 				UpdateMask: &fieldmaskpb.FieldMask{
 					Paths: []string{

--- a/proto/gen/googleapis/pubsub/apiv1/pubsubpb/schema_aiptest.pb.go
+++ b/proto/gen/googleapis/pubsub/apiv1/pubsubpb/schema_aiptest.pb.go
@@ -13,6 +13,34 @@ import (
 	testing "testing"
 )
 
+// SchemaServiceTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type SchemaServiceTestSuiteConfigProvider interface {
+	// SchemaServiceSchemaTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	SchemaTestSuiteConfig(t *testing.T) *SchemaServiceSchemaTestSuiteConfig
+}
+
+// TestSchemaService is the main entrypoint for starting the AIP tests.
+func TestSchemaService(t *testing.T, s SchemaServiceTestSuiteConfigProvider) {
+	testSchemaServiceSchemaTestSuiteConfig(t, s)
+}
+
+func testSchemaServiceSchemaTestSuiteConfig(t *testing.T, s SchemaServiceTestSuiteConfigProvider) {
+	t.Run("Schema", func(t *testing.T) {
+		config := s.SchemaTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method SchemaTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method SchemaServiceSchemaTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type SchemaServiceTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/pubsub/apiv1/pubsubpb/schema_aiptest.pb.go
+++ b/proto/gen/googleapis/pubsub/apiv1/pubsubpb/schema_aiptest.pb.go
@@ -22,15 +22,17 @@ type SchemaServiceTestSuite struct {
 func (fx SchemaServiceTestSuite) TestSchema(ctx context.Context, options SchemaServiceSchemaTestSuiteConfig) {
 	fx.T.Run("Schema", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() SchemaServiceServer { return fx.Server }
 		options.test(t)
 	})
 }
 
 type SchemaServiceSchemaTestSuiteConfig struct {
-	service    SchemaServiceServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() SchemaServiceServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -61,7 +63,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateSchema(fx.Context(), &CreateSchemaRequest{
+		_, err := fx.Service().CreateSchema(fx.Context(), &CreateSchemaRequest{
 			Parent: "",
 			Schema: fx.Create(fx.nextParent(t, false)),
 		})
@@ -71,7 +73,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateSchema(fx.Context(), &CreateSchemaRequest{
+		_, err := fx.Service().CreateSchema(fx.Context(), &CreateSchemaRequest{
 			Parent: "invalid resource name",
 			Schema: fx.Create(fx.nextParent(t, false)),
 		})
@@ -82,12 +84,12 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateSchema(fx.Context(), &CreateSchemaRequest{
+		msg, err := fx.Service().CreateSchema(fx.Context(), &CreateSchemaRequest{
 			Parent: parent,
 			Schema: fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetSchema(fx.Context(), &GetSchemaRequest{
+		persisted, err := fx.Service().GetSchema(fx.Context(), &GetSchemaRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -108,7 +110,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateSchema(fx.Context(), &CreateSchemaRequest{
+			_, err := fx.Service().CreateSchema(fx.Context(), &CreateSchemaRequest{
 				Parent: parent,
 				Schema: msg,
 			})
@@ -123,7 +125,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSchema(fx.Context(), &GetSchemaRequest{
+		_, err := fx.Service().GetSchema(fx.Context(), &GetSchemaRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -132,7 +134,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSchema(fx.Context(), &GetSchemaRequest{
+		_, err := fx.Service().GetSchema(fx.Context(), &GetSchemaRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -143,7 +145,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetSchema(fx.Context(), &GetSchemaRequest{
+		msg, err := fx.Service().GetSchema(fx.Context(), &GetSchemaRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -155,7 +157,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetSchema(fx.Context(), &GetSchemaRequest{
+		_, err := fx.Service().GetSchema(fx.Context(), &GetSchemaRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -164,7 +166,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetSchema(fx.Context(), &GetSchemaRequest{
+		_, err := fx.Service().GetSchema(fx.Context(), &GetSchemaRequest{
 			Name: "projects/-/schemas/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -177,7 +179,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListSchemas(fx.Context(), &ListSchemasRequest{
+		_, err := fx.Service().ListSchemas(fx.Context(), &ListSchemasRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -187,7 +189,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListSchemas(fx.Context(), &ListSchemasRequest{
+		_, err := fx.Service().ListSchemas(fx.Context(), &ListSchemasRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -198,7 +200,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListSchemas(fx.Context(), &ListSchemasRequest{
+		_, err := fx.Service().ListSchemas(fx.Context(), &ListSchemasRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -216,7 +218,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSchemas(fx.Context(), &ListSchemasRequest{
+		response, err := fx.Service().ListSchemas(fx.Context(), &ListSchemasRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -235,7 +237,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSchemas(fx.Context(), &ListSchemasRequest{
+		response, err := fx.Service().ListSchemas(fx.Context(), &ListSchemasRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -246,7 +248,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListSchemas(fx.Context(), &ListSchemasRequest{
+		response, err := fx.Service().ListSchemas(fx.Context(), &ListSchemasRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -260,7 +262,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*Schema, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListSchemas(fx.Context(), &ListSchemasRequest{
+			response, err := fx.Service().ListSchemas(fx.Context(), &ListSchemasRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -289,12 +291,12 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
+			_, err := fx.Service().DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListSchemas(fx.Context(), &ListSchemasRequest{
+		response, err := fx.Service().ListSchemas(fx.Context(), &ListSchemasRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -317,7 +319,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
+		_, err := fx.Service().DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -326,7 +328,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
+		_, err := fx.Service().DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -337,7 +339,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
+		_, err := fx.Service().DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -348,7 +350,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
+		_, err := fx.Service().DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -359,12 +361,12 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
+		deleted, err := fx.Service().DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
+		_, err = fx.Service().DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -373,7 +375,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
+		_, err := fx.Service().DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
 			Name: "projects/-/schemas/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -409,7 +411,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) maybeSkip(t *testing.T) {
 
 func (fx *SchemaServiceSchemaTestSuiteConfig) create(t *testing.T, parent string) *Schema {
 	t.Helper()
-	created, err := fx.service.CreateSchema(fx.Context(), &CreateSchemaRequest{
+	created, err := fx.Service().CreateSchema(fx.Context(), &CreateSchemaRequest{
 		Parent: parent,
 		Schema: fx.Create(parent),
 	})

--- a/proto/gen/googleapis/scheduler/apiv1/schedulerpb/cloudscheduler_aiptest.pb.go
+++ b/proto/gen/googleapis/scheduler/apiv1/schedulerpb/cloudscheduler_aiptest.pb.go
@@ -23,15 +23,17 @@ type CloudSchedulerTestSuite struct {
 func (fx CloudSchedulerTestSuite) TestJob(ctx context.Context, options CloudSchedulerJobTestSuiteConfig) {
 	fx.T.Run("Job", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() CloudSchedulerServer { return fx.Server }
 		options.test(t)
 	})
 }
 
 type CloudSchedulerJobTestSuiteConfig struct {
-	service    CloudSchedulerServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() CloudSchedulerServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -66,7 +68,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateJob(fx.Context(), &CreateJobRequest{
+		_, err := fx.Service().CreateJob(fx.Context(), &CreateJobRequest{
 			Parent: "",
 			Job:    fx.Create(fx.nextParent(t, false)),
 		})
@@ -76,7 +78,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateJob(fx.Context(), &CreateJobRequest{
+		_, err := fx.Service().CreateJob(fx.Context(), &CreateJobRequest{
 			Parent: "invalid resource name",
 			Job:    fx.Create(fx.nextParent(t, false)),
 		})
@@ -87,12 +89,12 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testCreate(t *testing.T) {
 	t.Run("persisted", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		msg, err := fx.service.CreateJob(fx.Context(), &CreateJobRequest{
+		msg, err := fx.Service().CreateJob(fx.Context(), &CreateJobRequest{
 			Parent: parent,
 			Job:    fx.Create(parent),
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetJob(fx.Context(), &GetJobRequest{
+		persisted, err := fx.Service().GetJob(fx.Context(), &GetJobRequest{
 			Name: msg.Name,
 		})
 		assert.NilError(t, err)
@@ -112,7 +114,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.TopicName = "invalid resource name"
-			_, err := fx.service.CreateJob(fx.Context(), &CreateJobRequest{
+			_, err := fx.Service().CreateJob(fx.Context(), &CreateJobRequest{
 				Parent: parent,
 				Job:    msg,
 			})
@@ -127,7 +129,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetJob(fx.Context(), &GetJobRequest{
+		_, err := fx.Service().GetJob(fx.Context(), &GetJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -136,7 +138,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetJob(fx.Context(), &GetJobRequest{
+		_, err := fx.Service().GetJob(fx.Context(), &GetJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -147,7 +149,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetJob(fx.Context(), &GetJobRequest{
+		msg, err := fx.Service().GetJob(fx.Context(), &GetJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -159,7 +161,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetJob(fx.Context(), &GetJobRequest{
+		_, err := fx.Service().GetJob(fx.Context(), &GetJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -168,7 +170,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetJob(fx.Context(), &GetJobRequest{
+		_, err := fx.Service().GetJob(fx.Context(), &GetJobRequest{
 			Name: "projects/-/locations/-/jobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -184,7 +186,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateJob(fx.Context(), &UpdateJobRequest{
+		_, err := fx.Service().UpdateJob(fx.Context(), &UpdateJobRequest{
 			Job: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -196,7 +198,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateJob(fx.Context(), &UpdateJobRequest{
+		_, err := fx.Service().UpdateJob(fx.Context(), &UpdateJobRequest{
 			Job: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -207,11 +209,11 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		updated, err := fx.service.UpdateJob(fx.Context(), &UpdateJobRequest{
+		updated, err := fx.Service().UpdateJob(fx.Context(), &UpdateJobRequest{
 			Job: created,
 		})
 		assert.NilError(t, err)
-		persisted, err := fx.service.GetJob(fx.Context(), &GetJobRequest{
+		persisted, err := fx.Service().GetJob(fx.Context(), &GetJobRequest{
 			Name: updated.Name,
 		})
 		assert.NilError(t, err)
@@ -225,7 +227,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateJob(fx.Context(), &UpdateJobRequest{
+		_, err := fx.Service().UpdateJob(fx.Context(), &UpdateJobRequest{
 			Job: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -234,7 +236,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateJob(fx.Context(), &UpdateJobRequest{
+		_, err := fx.Service().UpdateJob(fx.Context(), &UpdateJobRequest{
 			Job: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -252,7 +254,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListJobs(fx.Context(), &ListJobsRequest{
+		_, err := fx.Service().ListJobs(fx.Context(), &ListJobsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -262,7 +264,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListJobs(fx.Context(), &ListJobsRequest{
+		_, err := fx.Service().ListJobs(fx.Context(), &ListJobsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -273,7 +275,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListJobs(fx.Context(), &ListJobsRequest{
+		_, err := fx.Service().ListJobs(fx.Context(), &ListJobsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -291,7 +293,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListJobs(fx.Context(), &ListJobsRequest{
+		response, err := fx.Service().ListJobs(fx.Context(), &ListJobsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -310,7 +312,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListJobs(fx.Context(), &ListJobsRequest{
+		response, err := fx.Service().ListJobs(fx.Context(), &ListJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -321,7 +323,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListJobs(fx.Context(), &ListJobsRequest{
+		response, err := fx.Service().ListJobs(fx.Context(), &ListJobsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -335,7 +337,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*Job, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListJobs(fx.Context(), &ListJobsRequest{
+			response, err := fx.Service().ListJobs(fx.Context(), &ListJobsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -364,12 +366,12 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteJob(fx.Context(), &DeleteJobRequest{
+			_, err := fx.Service().DeleteJob(fx.Context(), &DeleteJobRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListJobs(fx.Context(), &ListJobsRequest{
+		response, err := fx.Service().ListJobs(fx.Context(), &ListJobsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -392,7 +394,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteJob(fx.Context(), &DeleteJobRequest{
+		_, err := fx.Service().DeleteJob(fx.Context(), &DeleteJobRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -401,7 +403,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteJob(fx.Context(), &DeleteJobRequest{
+		_, err := fx.Service().DeleteJob(fx.Context(), &DeleteJobRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -412,7 +414,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteJob(fx.Context(), &DeleteJobRequest{
+		_, err := fx.Service().DeleteJob(fx.Context(), &DeleteJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -423,7 +425,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteJob(fx.Context(), &DeleteJobRequest{
+		_, err := fx.Service().DeleteJob(fx.Context(), &DeleteJobRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -434,12 +436,12 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteJob(fx.Context(), &DeleteJobRequest{
+		deleted, err := fx.Service().DeleteJob(fx.Context(), &DeleteJobRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteJob(fx.Context(), &DeleteJobRequest{
+		_, err = fx.Service().DeleteJob(fx.Context(), &DeleteJobRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -448,7 +450,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteJob(fx.Context(), &DeleteJobRequest{
+		_, err := fx.Service().DeleteJob(fx.Context(), &DeleteJobRequest{
 			Name: "projects/-/locations/-/jobs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -484,7 +486,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) maybeSkip(t *testing.T) {
 
 func (fx *CloudSchedulerJobTestSuiteConfig) create(t *testing.T, parent string) *Job {
 	t.Helper()
-	created, err := fx.service.CreateJob(fx.Context(), &CreateJobRequest{
+	created, err := fx.Service().CreateJob(fx.Context(), &CreateJobRequest{
 		Parent: parent,
 		Job:    fx.Create(parent),
 	})

--- a/proto/gen/googleapis/scheduler/apiv1/schedulerpb/cloudscheduler_aiptest.pb.go
+++ b/proto/gen/googleapis/scheduler/apiv1/schedulerpb/cloudscheduler_aiptest.pb.go
@@ -14,6 +14,34 @@ import (
 	testing "testing"
 )
 
+// CloudSchedulerTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type CloudSchedulerTestSuiteConfigProvider interface {
+	// CloudSchedulerJobTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	JobTestSuiteConfig(t *testing.T) *CloudSchedulerJobTestSuiteConfig
+}
+
+// TestCloudScheduler is the main entrypoint for starting the AIP tests.
+func TestCloudScheduler(t *testing.T, s CloudSchedulerTestSuiteConfigProvider) {
+	testCloudSchedulerJobTestSuiteConfig(t, s)
+}
+
+func testCloudSchedulerJobTestSuiteConfig(t *testing.T, s CloudSchedulerTestSuiteConfigProvider) {
+	t.Run("Job", func(t *testing.T) {
+		config := s.JobTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method JobTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method CloudSchedulerJobTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type CloudSchedulerTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/spanner/admin/database/apiv1/databasepb/spanner_database_admin_aiptest.pb.go
+++ b/proto/gen/googleapis/spanner/admin/database/apiv1/databasepb/spanner_database_admin_aiptest.pb.go
@@ -15,6 +15,72 @@ import (
 	testing "testing"
 )
 
+// DatabaseAdminTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type DatabaseAdminTestSuiteConfigProvider interface {
+	// DatabaseAdminBackupTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	BackupTestSuiteConfig(t *testing.T) *DatabaseAdminBackupTestSuiteConfig
+	// DatabaseAdminDatabaseTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	DatabaseTestSuiteConfig(t *testing.T) *DatabaseAdminDatabaseTestSuiteConfig
+	// DatabaseAdminDatabaseRoleTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	DatabaseRoleTestSuiteConfig(t *testing.T) *DatabaseAdminDatabaseRoleTestSuiteConfig
+}
+
+// TestDatabaseAdmin is the main entrypoint for starting the AIP tests.
+func TestDatabaseAdmin(t *testing.T, s DatabaseAdminTestSuiteConfigProvider) {
+	testDatabaseAdminBackupTestSuiteConfig(t, s)
+	testDatabaseAdminDatabaseTestSuiteConfig(t, s)
+	testDatabaseAdminDatabaseRoleTestSuiteConfig(t, s)
+}
+
+func testDatabaseAdminBackupTestSuiteConfig(t *testing.T, s DatabaseAdminTestSuiteConfigProvider) {
+	t.Run("Backup", func(t *testing.T) {
+		config := s.BackupTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method BackupTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DatabaseAdminBackupTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testDatabaseAdminDatabaseTestSuiteConfig(t *testing.T, s DatabaseAdminTestSuiteConfigProvider) {
+	t.Run("Database", func(t *testing.T) {
+		config := s.DatabaseTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method DatabaseTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DatabaseAdminDatabaseTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testDatabaseAdminDatabaseRoleTestSuiteConfig(t *testing.T, s DatabaseAdminTestSuiteConfigProvider) {
+	t.Run("DatabaseRole", func(t *testing.T) {
+		config := s.DatabaseRoleTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method DatabaseRoleTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method DatabaseAdminDatabaseRoleTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type DatabaseAdminTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/spanner/admin/instance/apiv1/instancepb/spanner_instance_admin_aiptest.pb.go
+++ b/proto/gen/googleapis/spanner/admin/instance/apiv1/instancepb/spanner_instance_admin_aiptest.pb.go
@@ -15,6 +15,72 @@ import (
 	testing "testing"
 )
 
+// InstanceAdminTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type InstanceAdminTestSuiteConfigProvider interface {
+	// InstanceAdminInstanceTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	InstanceTestSuiteConfig(t *testing.T) *InstanceAdminInstanceTestSuiteConfig
+	// InstanceAdminInstanceConfigTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	InstanceConfigTestSuiteConfig(t *testing.T) *InstanceAdminInstanceConfigTestSuiteConfig
+	// InstanceAdminInstancePartitionTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	InstancePartitionTestSuiteConfig(t *testing.T) *InstanceAdminInstancePartitionTestSuiteConfig
+}
+
+// TestInstanceAdmin is the main entrypoint for starting the AIP tests.
+func TestInstanceAdmin(t *testing.T, s InstanceAdminTestSuiteConfigProvider) {
+	testInstanceAdminInstanceTestSuiteConfig(t, s)
+	testInstanceAdminInstanceConfigTestSuiteConfig(t, s)
+	testInstanceAdminInstancePartitionTestSuiteConfig(t, s)
+}
+
+func testInstanceAdminInstanceTestSuiteConfig(t *testing.T, s InstanceAdminTestSuiteConfigProvider) {
+	t.Run("Instance", func(t *testing.T) {
+		config := s.InstanceTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method InstanceTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method InstanceAdminInstanceTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testInstanceAdminInstanceConfigTestSuiteConfig(t *testing.T, s InstanceAdminTestSuiteConfigProvider) {
+	t.Run("InstanceConfig", func(t *testing.T) {
+		config := s.InstanceConfigTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method InstanceConfigTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method InstanceAdminInstanceConfigTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
+func testInstanceAdminInstancePartitionTestSuiteConfig(t *testing.T, s InstanceAdminTestSuiteConfigProvider) {
+	t.Run("InstancePartition", func(t *testing.T) {
+		config := s.InstancePartitionTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method InstancePartitionTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method InstanceAdminInstancePartitionTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type InstanceAdminTestSuite struct {
 	T *testing.T
 	// Server to test.

--- a/proto/gen/googleapis/spanner/admin/instance/apiv1/instancepb/spanner_instance_admin_aiptest.pb.go
+++ b/proto/gen/googleapis/spanner/admin/instance/apiv1/instancepb/spanner_instance_admin_aiptest.pb.go
@@ -23,7 +23,7 @@ type InstanceAdminTestSuite struct {
 
 func (fx InstanceAdminTestSuite) TestInstance(ctx context.Context, options InstanceAdminInstanceTestSuiteConfig) {
 	fx.T.Run("Instance", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -31,7 +31,7 @@ func (fx InstanceAdminTestSuite) TestInstance(ctx context.Context, options Insta
 
 func (fx InstanceAdminTestSuite) TestInstanceConfig(ctx context.Context, options InstanceAdminInstanceConfigTestSuiteConfig) {
 	fx.T.Run("InstanceConfig", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
@@ -39,17 +39,19 @@ func (fx InstanceAdminTestSuite) TestInstanceConfig(ctx context.Context, options
 
 func (fx InstanceAdminTestSuite) TestInstancePartition(ctx context.Context, options InstanceAdminInstancePartitionTestSuiteConfig) {
 	fx.T.Run("InstancePartition", func(t *testing.T) {
-		options.ctx = ctx
+		options.Context = func() context.Context { return ctx }
 		options.service = fx.Server
 		options.test(t)
 	})
 }
 
 type InstanceAdminInstanceTestSuiteConfig struct {
-	ctx        context.Context
 	service    InstanceAdminServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -81,7 +83,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+		_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 			Parent:   "",
 			Instance: fx.Create(fx.nextParent(t, false)),
 		})
@@ -91,7 +93,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+		_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 			Parent:   "invalid resource name",
 			Instance: fx.Create(fx.nextParent(t, false)),
 		})
@@ -112,7 +114,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -128,7 +130,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -144,7 +146,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -160,7 +162,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("autoscaling_limits")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -176,7 +178,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("autoscaling_targets")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -192,7 +194,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("high_priority_cpu_utilization_percent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -208,7 +210,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("storage_utilization_percent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -229,7 +231,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Config = "invalid resource name"
-			_, err := fx.service.CreateInstance(fx.ctx, &CreateInstanceRequest{
+			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -244,7 +246,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstance(fx.ctx, &GetInstanceRequest{
+		_, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -253,7 +255,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstance(fx.ctx, &GetInstanceRequest{
+		_, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -264,7 +266,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetInstance(fx.ctx, &GetInstanceRequest{
+		msg, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -276,7 +278,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetInstance(fx.ctx, &GetInstanceRequest{
+		_, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -285,7 +287,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstance(fx.ctx, &GetInstanceRequest{
+		_, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: "projects/-/instances/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -301,7 +303,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+		_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 			Instance: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -313,7 +315,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+		_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 			Instance: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -326,7 +328,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+		_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 			Instance: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -345,7 +347,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -359,7 +361,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -373,7 +375,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -387,7 +389,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("autoscaling_limits")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -401,7 +403,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("autoscaling_targets")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -415,7 +417,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("high_priority_cpu_utilization_percent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -429,7 +431,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("storage_utilization_percent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.ctx, &UpdateInstanceRequest{
+			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -443,7 +445,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListInstances(fx.ctx, &ListInstancesRequest{
+		_, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -453,7 +455,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstances(fx.ctx, &ListInstancesRequest{
+		_, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -464,7 +466,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstances(fx.ctx, &ListInstancesRequest{
+		_, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -482,7 +484,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstances(fx.ctx, &ListInstancesRequest{
+		response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -501,7 +503,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstances(fx.ctx, &ListInstancesRequest{
+		response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -512,7 +514,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstances(fx.ctx, &ListInstancesRequest{
+		response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -526,7 +528,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*Instance, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListInstances(fx.ctx, &ListInstancesRequest{
+			response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -555,12 +557,12 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteInstance(fx.ctx, &DeleteInstanceRequest{
+			_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListInstances(fx.ctx, &ListInstancesRequest{
+		response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -583,7 +585,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstance(fx.ctx, &DeleteInstanceRequest{
+		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -592,7 +594,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstance(fx.ctx, &DeleteInstanceRequest{
+		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -603,7 +605,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstance(fx.ctx, &DeleteInstanceRequest{
+		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -614,7 +616,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstance(fx.ctx, &DeleteInstanceRequest{
+		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -625,12 +627,12 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteInstance(fx.ctx, &DeleteInstanceRequest{
+		deleted, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteInstance(fx.ctx, &DeleteInstanceRequest{
+		_, err = fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -639,7 +641,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstance(fx.ctx, &DeleteInstanceRequest{
+		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: "projects/-/instances/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -680,10 +682,12 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) create(t *testing.T, parent stri
 }
 
 type InstanceAdminInstanceConfigTestSuiteConfig struct {
-	ctx        context.Context
 	service    InstanceAdminServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -715,7 +719,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstanceConfig(fx.ctx, &CreateInstanceConfigRequest{
+		_, err := fx.service.CreateInstanceConfig(fx.Context(), &CreateInstanceConfigRequest{
 			Parent:         "",
 			InstanceConfig: fx.Create(fx.nextParent(t, false)),
 		})
@@ -725,7 +729,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstanceConfig(fx.ctx, &CreateInstanceConfigRequest{
+		_, err := fx.service.CreateInstanceConfig(fx.Context(), &CreateInstanceConfigRequest{
 			Parent:         "invalid resource name",
 			InstanceConfig: fx.Create(fx.nextParent(t, false)),
 		})
@@ -745,7 +749,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.BaseConfig = "invalid resource name"
-			_, err := fx.service.CreateInstanceConfig(fx.ctx, &CreateInstanceConfigRequest{
+			_, err := fx.service.CreateInstanceConfig(fx.Context(), &CreateInstanceConfigRequest{
 				Parent:         parent,
 				InstanceConfig: msg,
 			})
@@ -760,7 +764,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstanceConfig(fx.ctx, &GetInstanceConfigRequest{
+		_, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -769,7 +773,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstanceConfig(fx.ctx, &GetInstanceConfigRequest{
+		_, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -780,7 +784,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetInstanceConfig(fx.ctx, &GetInstanceConfigRequest{
+		msg, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -792,7 +796,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetInstanceConfig(fx.ctx, &GetInstanceConfigRequest{
+		_, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -801,7 +805,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstanceConfig(fx.ctx, &GetInstanceConfigRequest{
+		_, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: "projects/-/instanceConfigs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -817,7 +821,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateInstanceConfig(fx.ctx, &UpdateInstanceConfigRequest{
+		_, err := fx.service.UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
 			InstanceConfig: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -829,7 +833,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateInstanceConfig(fx.ctx, &UpdateInstanceConfigRequest{
+		_, err := fx.service.UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
 			InstanceConfig: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -842,7 +846,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateInstanceConfig(fx.ctx, &UpdateInstanceConfigRequest{
+		_, err := fx.service.UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
 			InstanceConfig: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -851,7 +855,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateInstanceConfig(fx.ctx, &UpdateInstanceConfigRequest{
+		_, err := fx.service.UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
 			InstanceConfig: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -869,7 +873,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListInstanceConfigs(fx.ctx, &ListInstanceConfigsRequest{
+		_, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -879,7 +883,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstanceConfigs(fx.ctx, &ListInstanceConfigsRequest{
+		_, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -890,7 +894,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstanceConfigs(fx.ctx, &ListInstanceConfigsRequest{
+		_, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -908,7 +912,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstanceConfigs(fx.ctx, &ListInstanceConfigsRequest{
+		response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -927,7 +931,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstanceConfigs(fx.ctx, &ListInstanceConfigsRequest{
+		response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -938,7 +942,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstanceConfigs(fx.ctx, &ListInstanceConfigsRequest{
+		response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -952,7 +956,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*InstanceConfig, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListInstanceConfigs(fx.ctx, &ListInstanceConfigsRequest{
+			response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -981,12 +985,12 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteInstanceConfig(fx.ctx, &DeleteInstanceConfigRequest{
+			_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListInstanceConfigs(fx.ctx, &ListInstanceConfigsRequest{
+		response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -1009,7 +1013,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstanceConfig(fx.ctx, &DeleteInstanceConfigRequest{
+		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1018,7 +1022,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstanceConfig(fx.ctx, &DeleteInstanceConfigRequest{
+		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1029,7 +1033,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstanceConfig(fx.ctx, &DeleteInstanceConfigRequest{
+		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1040,7 +1044,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstanceConfig(fx.ctx, &DeleteInstanceConfigRequest{
+		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1051,12 +1055,12 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteInstanceConfig(fx.ctx, &DeleteInstanceConfigRequest{
+		deleted, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteInstanceConfig(fx.ctx, &DeleteInstanceConfigRequest{
+		_, err = fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1065,7 +1069,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstanceConfig(fx.ctx, &DeleteInstanceConfigRequest{
+		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: "projects/-/instanceConfigs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1076,7 +1080,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstanceConfig(fx.ctx, &DeleteInstanceConfigRequest{
+		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name,
 			Etag: `"99999"`,
 		})
@@ -1118,10 +1122,12 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) create(t *testing.T, paren
 }
 
 type InstanceAdminInstancePartitionTestSuiteConfig struct {
-	ctx        context.Context
 	service    InstanceAdminServer
 	currParent int
 
+	// Context should return a new context.
+	// The context will be used for several tests.
+	Context func() context.Context
 	// The parents to use when creating resources.
 	// At least one parent needs to be set. Depending on methods available on the resource,
 	// more may be required. If insufficient number of parents are
@@ -1153,7 +1159,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstancePartition(fx.ctx, &CreateInstancePartitionRequest{
+		_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 			Parent:            "",
 			InstancePartition: fx.Create(fx.nextParent(t, false)),
 		})
@@ -1163,7 +1169,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstancePartition(fx.ctx, &CreateInstancePartitionRequest{
+		_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 			Parent:            "invalid resource name",
 			InstancePartition: fx.Create(fx.nextParent(t, false)),
 		})
@@ -1184,7 +1190,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstancePartition(fx.ctx, &CreateInstancePartitionRequest{
+			_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 				Parent:            parent,
 				InstancePartition: msg,
 			})
@@ -1200,7 +1206,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstancePartition(fx.ctx, &CreateInstancePartitionRequest{
+			_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 				Parent:            parent,
 				InstancePartition: msg,
 			})
@@ -1216,7 +1222,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstancePartition(fx.ctx, &CreateInstancePartitionRequest{
+			_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 				Parent:            parent,
 				InstancePartition: msg,
 			})
@@ -1237,7 +1243,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 				t.Skip("not reachable")
 			}
 			container.Config = "invalid resource name"
-			_, err := fx.service.CreateInstancePartition(fx.ctx, &CreateInstancePartitionRequest{
+			_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 				Parent:            parent,
 				InstancePartition: msg,
 			})
@@ -1252,7 +1258,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstancePartition(fx.ctx, &GetInstancePartitionRequest{
+		_, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1261,7 +1267,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstancePartition(fx.ctx, &GetInstancePartitionRequest{
+		_, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1272,7 +1278,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetInstancePartition(fx.ctx, &GetInstancePartitionRequest{
+		msg, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1284,7 +1290,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetInstancePartition(fx.ctx, &GetInstancePartitionRequest{
+		_, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1293,7 +1299,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstancePartition(fx.ctx, &GetInstancePartitionRequest{
+		_, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: "projects/-/instances/-/instancePartitions/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1309,7 +1315,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateInstancePartition(fx.ctx, &UpdateInstancePartitionRequest{
+		_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 			InstancePartition: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1321,7 +1327,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateInstancePartition(fx.ctx, &UpdateInstancePartitionRequest{
+		_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 			InstancePartition: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1334,7 +1340,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateInstancePartition(fx.ctx, &UpdateInstancePartitionRequest{
+		_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 			InstancePartition: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1353,7 +1359,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstancePartition(fx.ctx, &UpdateInstancePartitionRequest{
+			_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 				InstancePartition: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1367,7 +1373,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstancePartition(fx.ctx, &UpdateInstancePartitionRequest{
+			_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 				InstancePartition: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1381,7 +1387,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstancePartition(fx.ctx, &UpdateInstancePartitionRequest{
+			_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 				InstancePartition: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1395,7 +1401,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListInstancePartitions(fx.ctx, &ListInstancePartitionsRequest{
+		_, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1405,7 +1411,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstancePartitions(fx.ctx, &ListInstancePartitionsRequest{
+		_, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -1416,7 +1422,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstancePartitions(fx.ctx, &ListInstancePartitionsRequest{
+		_, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -1434,7 +1440,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstancePartitions(fx.ctx, &ListInstancePartitionsRequest{
+		response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -1453,7 +1459,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstancePartitions(fx.ctx, &ListInstancePartitionsRequest{
+		response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -1464,7 +1470,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstancePartitions(fx.ctx, &ListInstancePartitionsRequest{
+		response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -1478,7 +1484,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 		msgs := make([]*InstancePartition, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListInstancePartitions(fx.ctx, &ListInstancePartitionsRequest{
+			response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -1507,12 +1513,12 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteInstancePartition(fx.ctx, &DeleteInstancePartitionRequest{
+			_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListInstancePartitions(fx.ctx, &ListInstancePartitionsRequest{
+		response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -1535,7 +1541,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstancePartition(fx.ctx, &DeleteInstancePartitionRequest{
+		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1544,7 +1550,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstancePartition(fx.ctx, &DeleteInstancePartitionRequest{
+		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1555,7 +1561,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstancePartition(fx.ctx, &DeleteInstancePartitionRequest{
+		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1566,7 +1572,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstancePartition(fx.ctx, &DeleteInstancePartitionRequest{
+		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1577,12 +1583,12 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteInstancePartition(fx.ctx, &DeleteInstancePartitionRequest{
+		deleted, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteInstancePartition(fx.ctx, &DeleteInstancePartitionRequest{
+		_, err = fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1591,7 +1597,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstancePartition(fx.ctx, &DeleteInstancePartitionRequest{
+		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: "projects/-/instances/-/instancePartitions/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1602,7 +1608,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstancePartition(fx.ctx, &DeleteInstancePartitionRequest{
+		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name,
 			Etag: `"99999"`,
 		})

--- a/proto/gen/googleapis/spanner/admin/instance/apiv1/instancepb/spanner_instance_admin_aiptest.pb.go
+++ b/proto/gen/googleapis/spanner/admin/instance/apiv1/instancepb/spanner_instance_admin_aiptest.pb.go
@@ -24,7 +24,7 @@ type InstanceAdminTestSuite struct {
 func (fx InstanceAdminTestSuite) TestInstance(ctx context.Context, options InstanceAdminInstanceTestSuiteConfig) {
 	fx.T.Run("Instance", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() InstanceAdminServer { return fx.Server }
 		options.test(t)
 	})
 }
@@ -32,7 +32,7 @@ func (fx InstanceAdminTestSuite) TestInstance(ctx context.Context, options Insta
 func (fx InstanceAdminTestSuite) TestInstanceConfig(ctx context.Context, options InstanceAdminInstanceConfigTestSuiteConfig) {
 	fx.T.Run("InstanceConfig", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() InstanceAdminServer { return fx.Server }
 		options.test(t)
 	})
 }
@@ -40,15 +40,17 @@ func (fx InstanceAdminTestSuite) TestInstanceConfig(ctx context.Context, options
 func (fx InstanceAdminTestSuite) TestInstancePartition(ctx context.Context, options InstanceAdminInstancePartitionTestSuiteConfig) {
 	fx.T.Run("InstancePartition", func(t *testing.T) {
 		options.Context = func() context.Context { return ctx }
-		options.service = fx.Server
+		options.Service = func() InstanceAdminServer { return fx.Server }
 		options.test(t)
 	})
 }
 
 type InstanceAdminInstanceTestSuiteConfig struct {
-	service    InstanceAdminServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() InstanceAdminServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -83,7 +85,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+		_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 			Parent:   "",
 			Instance: fx.Create(fx.nextParent(t, false)),
 		})
@@ -93,7 +95,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+		_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 			Parent:   "invalid resource name",
 			Instance: fx.Create(fx.nextParent(t, false)),
 		})
@@ -114,7 +116,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+			_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -130,7 +132,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+			_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -146,7 +148,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+			_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -162,7 +164,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("autoscaling_limits")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+			_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -178,7 +180,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("autoscaling_targets")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+			_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -194,7 +196,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("high_priority_cpu_utilization_percent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+			_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -210,7 +212,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("storage_utilization_percent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+			_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -231,7 +233,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.Config = "invalid resource name"
-			_, err := fx.service.CreateInstance(fx.Context(), &CreateInstanceRequest{
+			_, err := fx.Service().CreateInstance(fx.Context(), &CreateInstanceRequest{
 				Parent:   parent,
 				Instance: msg,
 			})
@@ -246,7 +248,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
+		_, err := fx.Service().GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -255,7 +257,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
+		_, err := fx.Service().GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -266,7 +268,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
+		msg, err := fx.Service().GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -278,7 +280,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
+		_, err := fx.Service().GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -287,7 +289,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstance(fx.Context(), &GetInstanceRequest{
+		_, err := fx.Service().GetInstance(fx.Context(), &GetInstanceRequest{
 			Name: "projects/-/instances/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -303,7 +305,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+		_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 			Instance: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -315,7 +317,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+		_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 			Instance: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -328,7 +330,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+		_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 			Instance: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -347,7 +349,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+			_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -361,7 +363,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+			_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -375,7 +377,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+			_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -389,7 +391,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("autoscaling_limits")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+			_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -403,7 +405,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("autoscaling_targets")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+			_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -417,7 +419,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("high_priority_cpu_utilization_percent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+			_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -431,7 +433,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testUpdate(t *testing.T) {
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("storage_utilization_percent")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstance(fx.Context(), &UpdateInstanceRequest{
+			_, err := fx.Service().UpdateInstance(fx.Context(), &UpdateInstanceRequest{
 				Instance: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -445,7 +447,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
+		_, err := fx.Service().ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -455,7 +457,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
+		_, err := fx.Service().ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -466,7 +468,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
+		_, err := fx.Service().ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -484,7 +486,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
+		response, err := fx.Service().ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -503,7 +505,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
+		response, err := fx.Service().ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -514,7 +516,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
+		response, err := fx.Service().ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -528,7 +530,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*Instance, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
+			response, err := fx.Service().ListInstances(fx.Context(), &ListInstancesRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -557,12 +559,12 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
+			_, err := fx.Service().DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListInstances(fx.Context(), &ListInstancesRequest{
+		response, err := fx.Service().ListInstances(fx.Context(), &ListInstancesRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -585,7 +587,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
+		_, err := fx.Service().DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -594,7 +596,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
+		_, err := fx.Service().DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -605,7 +607,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
+		_, err := fx.Service().DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -616,7 +618,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
+		_, err := fx.Service().DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -627,12 +629,12 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
+		deleted, err := fx.Service().DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
+		_, err = fx.Service().DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -641,7 +643,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstance(fx.Context(), &DeleteInstanceRequest{
+		_, err := fx.Service().DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 			Name: "projects/-/instances/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -682,9 +684,11 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) create(t *testing.T, parent stri
 }
 
 type InstanceAdminInstanceConfigTestSuiteConfig struct {
-	service    InstanceAdminServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() InstanceAdminServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -719,7 +723,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstanceConfig(fx.Context(), &CreateInstanceConfigRequest{
+		_, err := fx.Service().CreateInstanceConfig(fx.Context(), &CreateInstanceConfigRequest{
 			Parent:         "",
 			InstanceConfig: fx.Create(fx.nextParent(t, false)),
 		})
@@ -729,7 +733,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testCreate(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstanceConfig(fx.Context(), &CreateInstanceConfigRequest{
+		_, err := fx.Service().CreateInstanceConfig(fx.Context(), &CreateInstanceConfigRequest{
 			Parent:         "invalid resource name",
 			InstanceConfig: fx.Create(fx.nextParent(t, false)),
 		})
@@ -749,7 +753,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testCreate(t *testing.T) {
 				t.Skip("not reachable")
 			}
 			container.BaseConfig = "invalid resource name"
-			_, err := fx.service.CreateInstanceConfig(fx.Context(), &CreateInstanceConfigRequest{
+			_, err := fx.Service().CreateInstanceConfig(fx.Context(), &CreateInstanceConfigRequest{
 				Parent:         parent,
 				InstanceConfig: msg,
 			})
@@ -764,7 +768,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
+		_, err := fx.Service().GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -773,7 +777,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
+		_, err := fx.Service().GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -784,7 +788,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
+		msg, err := fx.Service().GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -796,7 +800,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
+		_, err := fx.Service().GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -805,7 +809,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
+		_, err := fx.Service().GetInstanceConfig(fx.Context(), &GetInstanceConfigRequest{
 			Name: "projects/-/instanceConfigs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -821,7 +825,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
+		_, err := fx.Service().UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
 			InstanceConfig: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -833,7 +837,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testUpdate(t *testing.T) {
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
+		_, err := fx.Service().UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
 			InstanceConfig: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -846,7 +850,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testUpdate(t *testing.T) {
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
+		_, err := fx.Service().UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
 			InstanceConfig: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -855,7 +859,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testUpdate(t *testing.T) {
 	// The method should fail with InvalidArgument if the update_mask is invalid.
 	t.Run("invalid update mask", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
+		_, err := fx.Service().UpdateInstanceConfig(fx.Context(), &UpdateInstanceConfigRequest{
 			InstanceConfig: created,
 			UpdateMask: &fieldmaskpb.FieldMask{
 				Paths: []string{
@@ -873,7 +877,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
+		_, err := fx.Service().ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -883,7 +887,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
+		_, err := fx.Service().ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -894,7 +898,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
+		_, err := fx.Service().ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -912,7 +916,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
+		response, err := fx.Service().ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -931,7 +935,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
+		response, err := fx.Service().ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -942,7 +946,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
+		response, err := fx.Service().ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -956,7 +960,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 		msgs := make([]*InstanceConfig, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
+			response, err := fx.Service().ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -985,12 +989,12 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
+			_, err := fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
+		response, err := fx.Service().ListInstanceConfigs(fx.Context(), &ListInstanceConfigsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -1013,7 +1017,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
+		_, err := fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1022,7 +1026,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
+		_, err := fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1033,7 +1037,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
+		_, err := fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1044,7 +1048,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
+		_, err := fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1055,12 +1059,12 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
+		deleted, err := fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
+		_, err = fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1069,7 +1073,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
+		_, err := fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: "projects/-/instanceConfigs/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1080,7 +1084,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testDelete(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
+		_, err := fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 			Name: created.Name,
 			Etag: `"99999"`,
 		})
@@ -1122,9 +1126,11 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) create(t *testing.T, paren
 }
 
 type InstanceAdminInstancePartitionTestSuiteConfig struct {
-	service    InstanceAdminServer
 	currParent int
 
+	// Service should return the service that should be tested.
+	// The service will be used for several tests.
+	Service func() InstanceAdminServer
 	// Context should return a new context.
 	// The context will be used for several tests.
 	Context func() context.Context
@@ -1159,7 +1165,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 	// Method should fail with InvalidArgument if no parent is provided.
 	t.Run("missing parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
+		_, err := fx.Service().CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 			Parent:            "",
 			InstancePartition: fx.Create(fx.nextParent(t, false)),
 		})
@@ -1169,7 +1175,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
+		_, err := fx.Service().CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 			Parent:            "invalid resource name",
 			InstancePartition: fx.Create(fx.nextParent(t, false)),
 		})
@@ -1190,7 +1196,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
+			_, err := fx.Service().CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 				Parent:            parent,
 				InstancePartition: msg,
 			})
@@ -1206,7 +1212,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
+			_, err := fx.Service().CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 				Parent:            parent,
 				InstancePartition: msg,
 			})
@@ -1222,7 +1228,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
+			_, err := fx.Service().CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 				Parent:            parent,
 				InstancePartition: msg,
 			})
@@ -1243,7 +1249,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testCreate(t *testing.T
 				t.Skip("not reachable")
 			}
 			container.Config = "invalid resource name"
-			_, err := fx.service.CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
+			_, err := fx.Service().CreateInstancePartition(fx.Context(), &CreateInstancePartitionRequest{
 				Parent:            parent,
 				InstancePartition: msg,
 			})
@@ -1258,7 +1264,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
+		_, err := fx.Service().GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1267,7 +1273,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
+		_, err := fx.Service().GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1278,7 +1284,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		msg, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
+		msg, err := fx.Service().GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1290,7 +1296,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
+		_, err := fx.Service().GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1299,7 +1305,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testGet(t *testing.T) {
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
+		_, err := fx.Service().GetInstancePartition(fx.Context(), &GetInstancePartitionRequest{
 			Name: "projects/-/instances/-/instancePartitions/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1315,7 +1321,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = ""
-		_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
+		_, err := fx.Service().UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 			InstancePartition: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1327,7 +1333,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 		parent := fx.nextParent(t, false)
 		msg := fx.Update(parent)
 		msg.Name = "invalid resource name"
-		_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
+		_, err := fx.Service().UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 			InstancePartition: msg,
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1340,7 +1346,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 		fx.maybeSkip(t)
 		msg := fx.Update(parent)
 		msg.Name = created.Name + "notfound"
-		_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
+		_, err := fx.Service().UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 			InstancePartition: msg,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1359,7 +1365,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
+			_, err := fx.Service().UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 				InstancePartition: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1373,7 +1379,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("config")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
+			_, err := fx.Service().UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 				InstancePartition: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1387,7 +1393,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testUpdate(t *testing.T
 			}
 			fd := container.ProtoReflect().Descriptor().Fields().ByName("display_name")
 			container.ProtoReflect().Clear(fd)
-			_, err := fx.service.UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
+			_, err := fx.Service().UpdateInstancePartition(fx.Context(), &UpdateInstancePartitionRequest{
 				InstancePartition: msg,
 			})
 			assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1401,7 +1407,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	// Method should fail with InvalidArgument if provided parent is invalid.
 	t.Run("invalid parent", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
+		_, err := fx.Service().ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1411,7 +1417,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	t.Run("invalid page token", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
+		_, err := fx.Service().ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:    parent,
 			PageToken: "invalid page token",
 		})
@@ -1422,7 +1428,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	t.Run("negative page size", func(t *testing.T) {
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
-		_, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
+		_, err := fx.Service().ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: -10,
 		})
@@ -1440,7 +1446,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	// under that parent.
 	t.Run("isolation", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
+		response, err := fx.Service().ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: 999,
 		})
@@ -1459,7 +1465,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	// If there are no more resources, next_page_token should not be set.
 	t.Run("last page", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
+		response, err := fx.Service().ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount,
 		})
@@ -1470,7 +1476,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	// If there are more resources, next_page_token should be set.
 	t.Run("more pages", func(t *testing.T) {
 		fx.maybeSkip(t)
-		response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
+		response, err := fx.Service().ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: resourcesCount - 1,
 		})
@@ -1484,7 +1490,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 		msgs := make([]*InstancePartition, 0, resourcesCount)
 		var nextPageToken string
 		for {
-			response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
+			response, err := fx.Service().ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 				Parent:    parent,
 				PageSize:  1,
 				PageToken: nextPageToken,
@@ -1513,12 +1519,12 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 		fx.maybeSkip(t)
 		const deleteCount = 5
 		for i := 0; i < deleteCount; i++ {
-			_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
+			_, err := fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 				Name: parentMsgs[i].Name,
 			})
 			assert.NilError(t, err)
 		}
-		response, err := fx.service.ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
+		response, err := fx.Service().ListInstancePartitions(fx.Context(), &ListInstancePartitionsRequest{
 			Parent:   parent,
 			PageSize: 9999,
 		})
@@ -1541,7 +1547,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 	// Method should fail with InvalidArgument if no name is provided.
 	t.Run("missing name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
+		_, err := fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: "",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1550,7 +1556,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 	// Method should fail with InvalidArgument if the provided name is not valid.
 	t.Run("invalid name", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
+		_, err := fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: "invalid resource name",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1561,7 +1567,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
+		_, err := fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
@@ -1572,7 +1578,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
+		_, err := fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name + "notfound",
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1583,12 +1589,12 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		deleted, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
+		deleted, err := fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name,
 		})
 		assert.NilError(t, err)
 		_ = deleted
-		_, err = fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
+		_, err = fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name,
 		})
 		assert.Equal(t, codes.NotFound, status.Code(err), err)
@@ -1597,7 +1603,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 	// Method should fail with InvalidArgument if the provided name only contains wildcards ('-')
 	t.Run("only wildcards", func(t *testing.T) {
 		fx.maybeSkip(t)
-		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
+		_, err := fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: "projects/-/instances/-/instancePartitions/-",
 		})
 		assert.Equal(t, codes.InvalidArgument, status.Code(err), err)
@@ -1608,7 +1614,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testDelete(t *testing.T
 		fx.maybeSkip(t)
 		parent := fx.nextParent(t, false)
 		created := fx.create(t, parent)
-		_, err := fx.service.DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
+		_, err := fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 			Name: created.Name,
 			Etag: `"99999"`,
 		})

--- a/proto/gen/googleapis/spanner/apiv1/spannerpb/spanner_aiptest.pb.go
+++ b/proto/gen/googleapis/spanner/apiv1/spannerpb/spanner_aiptest.pb.go
@@ -12,6 +12,34 @@ import (
 	testing "testing"
 )
 
+// SpannerTestSuiteConfigProvider is the interface to implement to decide which resources
+// that should be tested and how it's configured.
+type SpannerTestSuiteConfigProvider interface {
+	// SpannerSessionTestSuiteConfig should return a config, or nil, which means that the tests will be skipped.
+	SessionTestSuiteConfig(t *testing.T) *SpannerSessionTestSuiteConfig
+}
+
+// TestSpanner is the main entrypoint for starting the AIP tests.
+func TestSpanner(t *testing.T, s SpannerTestSuiteConfigProvider) {
+	testSpannerSessionTestSuiteConfig(t, s)
+}
+
+func testSpannerSessionTestSuiteConfig(t *testing.T, s SpannerTestSuiteConfigProvider) {
+	t.Run("Session", func(t *testing.T) {
+		config := s.SessionTestSuiteConfig(t)
+		if config == nil {
+			t.Skip("Method SessionTestSuiteConfig not implemented")
+		}
+		if config.Service == nil {
+			t.Skip("Method SpannerSessionTestSuiteConfig.Service() not implemented")
+		}
+		if config.Context == nil {
+			config.Context = func() context.Context { return context.Background() }
+		}
+		config.test(t)
+	})
+}
+
 type SpannerTestSuite struct {
 	T *testing.T
 	// Server to test.


### PR DESCRIPTION
### TL;DR

With this setup you need to explicit **opt-out** tests instead of explicit **opt-int**.

### Why

We have noticed historically, that when people adds new
resources, it's easy to forget to implement the newly
generated AIP tests, either directly or later.

### How

This commit tries to solve that issue by introducing a
main entrypoint to execute the tests, which takes a interface
that the user needs to implement.

When a new resource is added, the interface will be extended with
another method that the user needs to implement, if not, a compilation
error would be raised.

The user can choose to return `nil` to indicate that it can't be
implemented right directly.

All tests will still be executed, but if not implemented it will be
skipped, this to show it's available but not implemented.

This commit is backwards compatible with the current test setup.

For example usage, see `examples/`.