### PR TITLE
docs(readme): add note on 'go install' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ protoc
 
 This can also be done via a
 [buf generate](https://docs.buf.build/generate/usage) template. See
-[buf.gen.yaml](./buf.gen.yaml) for an example.
+[buf.gen.yaml](./proto/buf.gen.yaml) for an example.
 
 ### Step 4: Run tests
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ service FreightService {
 
 ### Step 2: Install the generator
 
-Download a prebuilt binary from [releases](./releases) and put it in your PATH.
+Either install using `go install`:
+
+```bash
+go install github.com/einride/protoc-gen-go-aip-test@latest
+```
+
+Or download a prebuilt binary from [releases](./releases) and put it in your
+PATH.
 
 The generator can also be built from source using Go.
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Either install using `go install`:
 go install github.com/einride/protoc-gen-go-aip-test@latest
 ```
 
-Or download a prebuilt binary from [releases](./releases) and put it in your
-PATH.
+Or download a prebuilt binary from
+[releases](https://github.com/einride/protoc-gen-go-aip-test/releases) and put
+it in your PATH.
 
 The generator can also be built from source using Go.
 


### PR DESCRIPTION
### Why?

I was lacking information on how to install the binary using `go install`.

### What?

- **docs(readme): fix link**
- **docs(readme): add note on 'go install'**


### Notes

Closes #277