### PR TITLE
remove create > invalid user settable id > too short test because min allowed is 1

### DIFF
--- a/internal/aiptest/create/user_settable_id.go
+++ b/internal/aiptest/create/user_settable_id.go
@@ -93,10 +93,6 @@ var invalidUserSettableID = suite.Test{
 				id:   "fooö",
 			},
 			{
-				name: "too short",
-				id:   "foo",
-			},
-			{
 				name: "too long",
 				id:   "f" + strings.Repeat("o", 63),
 			},

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -207,10 +207,6 @@ func (fx *FreightServiceShipperTestSuiteConfig) testCreate(t *testing.T) {
 				id:   "fooö",
 			},
 			{
-				name: "too short",
-				id:   "foo",
-			},
-			{
 				name: "too long",
 				id:   "fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo",
 			},
@@ -853,10 +849,6 @@ func (fx *FreightServiceSiteTestSuiteConfig) testCreate(t *testing.T) {
 			{
 				name: "ends with non ascii",
 				id:   "fooö",
-			},
-			{
-				name: "too short",
-				id:   "foo",
 			},
 			{
 				name: "too long",


### PR DESCRIPTION
**TL;DR:** The `Create/invalid_user_settable_id/too_short` generated test is not following AIP-122 because single-letter ID is valid.

---

https://google.aip.dev/122#resource-id-segments mentions the regex to validate the user-provided ID:
```
^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$
```

Which follows RFC-1034 rule for labels. Quoting https://www.rfc-editor.org/rfc/rfc1034 (ctrl+f "ARPANET host names")

> The labels must follow the rules for ARPANET host names.  They must
> start with a letter, end with a letter or digit, and have as interior
> characters only letters, digits, and hyphen.  There are also some
> restrictions on the length.  **Labels must be 63 characters or less.**

A valid label can be a single letter. The generated test `too short` for user settable ID is not feasible because trying to test with an ID with a length equal to 0 = empty = the server will fall back to system-generated ID:

> An API may allow the {resource}_id field have the [field_behavior](https://google.aip.dev/203) OPTIONAL, **and generate a system-generated ID if one is not specified.**

Source: https://google.aip.dev/133#user-specified-ids
