### PR TITLE
feat: Run integration tests in parallel with fewer list items

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ Sample skips:
 - `"Get/invalid_name"` skips the "invalid name" test for Get standard method.
 - `"Get"` skips all tests for a Get standard method.
 
+### Parallel tests
+
+The `*testing.T` passed to each config provider method is the subtest's
+`*testing.T`. To run resource tests in parallel, call `t.Parallel()` at the top
+of each provider method:
+
+```go
+func (a *myTests) FreightServiceShipper(t *testing.T) *examplefreightv1.FreightServiceShipperTestSuiteConfig {
+    t.Parallel()
+    // ...
+}
+```
+
 ## Suites
 
 <!-- BEGIN suites -->

--- a/internal/aiptest/list/deleted.go
+++ b/internal/aiptest/list/deleted.go
@@ -28,7 +28,8 @@ var deleted = suite.Test{
 			listMethod.Output.Desc,
 			scope.Resource,
 		).Name()))
-		f.P("const deleteCount = 5")
+		// deleteCount needs to be lower than the resourcesCounts in list.go
+		f.P("const deleteCount = 3")
 		f.P("for i := 0; i < deleteCount; i++ {")
 		util.MethodDelete{
 			Method:      deleteMethod,

--- a/internal/aiptest/list/list.go
+++ b/internal/aiptest/list/list.go
@@ -29,7 +29,7 @@ var withResourcesGroup = suite.TestGroup{
 		onlyif.HasParent,
 	),
 	GenerateBefore: func(f *protogen.GeneratedFile, scope suite.Scope) error {
-		f.P("const resourcesCount = 15")
+		f.P("const resourcesCount = 5")
 		f.P("parent := ", ident.FixtureNextParent, "(t, true)")
 		f.P("parentMsgs := make([]*", scope.Message.GoIdent, ", resourcesCount)")
 		f.P("for i := 0; i < resourcesCount; i++ {")
@@ -53,7 +53,7 @@ var withDeletedResourcesGroup = suite.TestGroup{
 		onlyif.HasParent,
 	),
 	GenerateBefore: func(f *protogen.GeneratedFile, scope suite.Scope) error {
-		f.P("const resourcesCount = 15")
+		f.P("const resourcesCount = 5")
 		f.P("parent := ", ident.FixtureNextParent, "(t, true)")
 		f.P("parentMsgs := make([]*", scope.Message.GoIdent, ", resourcesCount)")
 		f.P("for i := 0; i < resourcesCount; i++ {")

--- a/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
+++ b/proto/gen/einride/example/freight/v1/freight_service_aiptest.pb.go
@@ -1439,7 +1439,7 @@ func (fx *FreightServiceSiteTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Site, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1532,7 +1532,7 @@ func (fx *FreightServiceSiteTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Site, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1542,7 +1542,7 @@ func (fx *FreightServiceSiteTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteSite(fx.Context(), &DeleteSiteRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/dataset_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/dataset_service_aiptest.pb.go
@@ -257,7 +257,7 @@ func (fx *DatasetServiceAnnotationTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Annotation, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -573,7 +573,7 @@ func (fx *DatasetServiceDataItemTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*DataItem, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1122,7 +1122,7 @@ func (fx *DatasetServiceDatasetTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Dataset, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1215,7 +1215,7 @@ func (fx *DatasetServiceDatasetTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Dataset, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1225,7 +1225,7 @@ func (fx *DatasetServiceDatasetTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteDataset(fx.Context(), &DeleteDatasetRequest{
 					Name: parentMsgs[i].Name,
@@ -1495,7 +1495,7 @@ func (fx *DatasetServiceDatasetVersionTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*DatasetVersion, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1588,7 +1588,7 @@ func (fx *DatasetServiceDatasetVersionTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*DatasetVersion, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1598,7 +1598,7 @@ func (fx *DatasetServiceDatasetVersionTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteDatasetVersion(fx.Context(), &DeleteDatasetVersionRequest{
 					Name: parentMsgs[i].Name,
@@ -1791,7 +1791,7 @@ func (fx *DatasetServiceSavedQueryTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*SavedQuery, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1884,7 +1884,7 @@ func (fx *DatasetServiceSavedQueryTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*SavedQuery, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1894,7 +1894,7 @@ func (fx *DatasetServiceSavedQueryTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteSavedQuery(fx.Context(), &DeleteSavedQueryRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/deployment_resource_pool_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/deployment_resource_pool_service_aiptest.pb.go
@@ -252,7 +252,7 @@ func (fx *DeploymentResourcePoolServiceDeploymentResourcePoolTestSuiteConfig) te
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*DeploymentResourcePool, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -345,7 +345,7 @@ func (fx *DeploymentResourcePoolServiceDeploymentResourcePoolTestSuiteConfig) te
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*DeploymentResourcePool, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -355,7 +355,7 @@ func (fx *DeploymentResourcePoolServiceDeploymentResourcePoolTestSuiteConfig) te
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteDeploymentResourcePool(fx.Context(), &DeleteDeploymentResourcePoolRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/endpoint_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/endpoint_service_aiptest.pb.go
@@ -462,7 +462,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Endpoint, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -555,7 +555,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Endpoint, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -565,7 +565,7 @@ func (fx *EndpointServiceEndpointTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteEndpoint(fx.Context(), &DeleteEndpointRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_online_store_admin_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_online_store_admin_service_aiptest.pb.go
@@ -459,7 +459,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*FeatureOnlineStore, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -552,7 +552,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*FeatureOnlineStore, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -562,7 +562,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureOnlineStoreTestSuiteConfig) testL
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteFeatureOnlineStore(fx.Context(), &DeleteFeatureOnlineStoreRequest{
 					Name: parentMsgs[i].Name,
@@ -1037,7 +1037,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*FeatureView, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1130,7 +1130,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*FeatureView, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1140,7 +1140,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewTestSuiteConfig) testList(t *
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteFeatureView(fx.Context(), &DeleteFeatureViewRequest{
 					Name: parentMsgs[i].Name,
@@ -1387,7 +1387,7 @@ func (fx *FeatureOnlineStoreAdminServiceFeatureViewSyncTestSuiteConfig) testList
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*FeatureViewSync, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_registry_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/feature_registry_service_aiptest.pb.go
@@ -329,7 +329,7 @@ func (fx *FeatureRegistryServiceFeatureTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Feature, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -422,7 +422,7 @@ func (fx *FeatureRegistryServiceFeatureTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Feature, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -432,7 +432,7 @@ func (fx *FeatureRegistryServiceFeatureTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteFeature(fx.Context(), &DeleteFeatureRequest{
 					Name: parentMsgs[i].Name,
@@ -877,7 +877,7 @@ func (fx *FeatureRegistryServiceFeatureGroupTestSuiteConfig) testList(t *testing
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*FeatureGroup, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -970,7 +970,7 @@ func (fx *FeatureRegistryServiceFeatureGroupTestSuiteConfig) testList(t *testing
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*FeatureGroup, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -980,7 +980,7 @@ func (fx *FeatureRegistryServiceFeatureGroupTestSuiteConfig) testList(t *testing
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteFeatureGroup(fx.Context(), &DeleteFeatureGroupRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/featurestore_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/featurestore_service_aiptest.pb.go
@@ -360,7 +360,7 @@ func (fx *FeaturestoreServiceEntityTypeTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*EntityType, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -453,7 +453,7 @@ func (fx *FeaturestoreServiceEntityTypeTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*EntityType, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -463,7 +463,7 @@ func (fx *FeaturestoreServiceEntityTypeTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteEntityType(fx.Context(), &DeleteEntityTypeRequest{
 					Name: parentMsgs[i].Name,
@@ -853,7 +853,7 @@ func (fx *FeaturestoreServiceFeatureTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Feature, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -946,7 +946,7 @@ func (fx *FeaturestoreServiceFeatureTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Feature, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -956,7 +956,7 @@ func (fx *FeaturestoreServiceFeatureTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteFeature(fx.Context(), &DeleteFeatureRequest{
 					Name: parentMsgs[i].Name,
@@ -1396,7 +1396,7 @@ func (fx *FeaturestoreServiceFeaturestoreTestSuiteConfig) testList(t *testing.T)
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Featurestore, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1489,7 +1489,7 @@ func (fx *FeaturestoreServiceFeaturestoreTestSuiteConfig) testList(t *testing.T)
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Featurestore, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1499,7 +1499,7 @@ func (fx *FeaturestoreServiceFeaturestoreTestSuiteConfig) testList(t *testing.T)
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteFeaturestore(fx.Context(), &DeleteFeaturestoreRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_endpoint_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_endpoint_service_aiptest.pb.go
@@ -441,7 +441,7 @@ func (fx *IndexEndpointServiceIndexEndpointTestSuiteConfig) testList(t *testing.
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*IndexEndpoint, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -534,7 +534,7 @@ func (fx *IndexEndpointServiceIndexEndpointTestSuiteConfig) testList(t *testing.
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*IndexEndpoint, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -544,7 +544,7 @@ func (fx *IndexEndpointServiceIndexEndpointTestSuiteConfig) testList(t *testing.
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteIndexEndpoint(fx.Context(), &DeleteIndexEndpointRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/index_service_aiptest.pb.go
@@ -370,7 +370,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Index, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -463,7 +463,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Index, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -473,7 +473,7 @@ func (fx *IndexServiceIndexTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteIndex(fx.Context(), &DeleteIndexRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/job_service_aiptest.pb.go
@@ -709,7 +709,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*BatchPredictionJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -802,7 +802,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*BatchPredictionJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -812,7 +812,7 @@ func (fx *JobServiceBatchPredictionJobTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteBatchPredictionJob(fx.Context(), &DeleteBatchPredictionJobRequest{
 					Name: parentMsgs[i].Name,
@@ -1284,7 +1284,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*CustomJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1377,7 +1377,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*CustomJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1387,7 +1387,7 @@ func (fx *JobServiceCustomJobTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteCustomJob(fx.Context(), &DeleteCustomJobRequest{
 					Name: parentMsgs[i].Name,
@@ -1831,7 +1831,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*DataLabelingJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1924,7 +1924,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*DataLabelingJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1934,7 +1934,7 @@ func (fx *JobServiceDataLabelingJobTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteDataLabelingJob(fx.Context(), &DeleteDataLabelingJobRequest{
 					Name: parentMsgs[i].Name,
@@ -2486,7 +2486,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*HyperparameterTuningJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -2579,7 +2579,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*HyperparameterTuningJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -2589,7 +2589,7 @@ func (fx *JobServiceHyperparameterTuningJobTestSuiteConfig) testList(t *testing.
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteHyperparameterTuningJob(fx.Context(), &DeleteHyperparameterTuningJobRequest{
 					Name: parentMsgs[i].Name,
@@ -3283,7 +3283,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*ModelDeploymentMonitoringJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -3376,7 +3376,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*ModelDeploymentMonitoringJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -3386,7 +3386,7 @@ func (fx *JobServiceModelDeploymentMonitoringJobTestSuiteConfig) testList(t *tes
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteModelDeploymentMonitoringJob(fx.Context(), &DeleteModelDeploymentMonitoringJobRequest{
 					Name: parentMsgs[i].Name,
@@ -4002,7 +4002,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*NasJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -4095,7 +4095,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*NasJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -4105,7 +4105,7 @@ func (fx *JobServiceNasJobTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteNasJob(fx.Context(), &DeleteNasJobRequest{
 					Name: parentMsgs[i].Name,
@@ -4356,7 +4356,7 @@ func (fx *JobServiceNasTrialDetailTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*NasTrialDetail, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/metadata_service_aiptest.pb.go
@@ -469,7 +469,7 @@ func (fx *MetadataServiceArtifactTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Artifact, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -562,7 +562,7 @@ func (fx *MetadataServiceArtifactTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Artifact, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -572,7 +572,7 @@ func (fx *MetadataServiceArtifactTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteArtifact(fx.Context(), &DeleteArtifactRequest{
 					Name: parentMsgs[i].Name,
@@ -1019,7 +1019,7 @@ func (fx *MetadataServiceContextTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Context, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1112,7 +1112,7 @@ func (fx *MetadataServiceContextTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Context, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1122,7 +1122,7 @@ func (fx *MetadataServiceContextTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteContext(fx.Context(), &DeleteContextRequest{
 					Name: parentMsgs[i].Name,
@@ -1569,7 +1569,7 @@ func (fx *MetadataServiceExecutionTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Execution, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1662,7 +1662,7 @@ func (fx *MetadataServiceExecutionTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Execution, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1672,7 +1672,7 @@ func (fx *MetadataServiceExecutionTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteExecution(fx.Context(), &DeleteExecutionRequest{
 					Name: parentMsgs[i].Name,
@@ -2010,7 +2010,7 @@ func (fx *MetadataServiceMetadataSchemaTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*MetadataSchema, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -2305,7 +2305,7 @@ func (fx *MetadataServiceMetadataStoreTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*MetadataStore, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -2398,7 +2398,7 @@ func (fx *MetadataServiceMetadataStoreTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*MetadataStore, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -2408,7 +2408,7 @@ func (fx *MetadataServiceMetadataStoreTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteMetadataStore(fx.Context(), &DeleteMetadataStoreRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/model_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/model_service_aiptest.pb.go
@@ -533,7 +533,7 @@ func (fx *ModelServiceModelTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Model, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -626,7 +626,7 @@ func (fx *ModelServiceModelTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Model, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -636,7 +636,7 @@ func (fx *ModelServiceModelTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteModel(fx.Context(), &DeleteModelRequest{
 					Name: parentMsgs[i].Name,
@@ -887,7 +887,7 @@ func (fx *ModelServiceModelEvaluationTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*ModelEvaluation, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1137,7 +1137,7 @@ func (fx *ModelServiceModelEvaluationSliceTestSuiteConfig) testList(t *testing.T
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*ModelEvaluationSlice, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/pipeline_service_aiptest.pb.go
@@ -316,7 +316,7 @@ func (fx *PipelineServicePipelineJobTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*PipelineJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -409,7 +409,7 @@ func (fx *PipelineServicePipelineJobTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*PipelineJob, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -419,7 +419,7 @@ func (fx *PipelineServicePipelineJobTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeletePipelineJob(fx.Context(), &DeletePipelineJobRequest{
 					Name: parentMsgs[i].Name,
@@ -1103,7 +1103,7 @@ func (fx *PipelineServiceTrainingPipelineTestSuiteConfig) testList(t *testing.T)
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*TrainingPipeline, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1196,7 +1196,7 @@ func (fx *PipelineServiceTrainingPipelineTestSuiteConfig) testList(t *testing.T)
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*TrainingPipeline, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1206,7 +1206,7 @@ func (fx *PipelineServiceTrainingPipelineTestSuiteConfig) testList(t *testing.T)
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteTrainingPipeline(fx.Context(), &DeleteTrainingPipelineRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/schedule_service_aiptest.pb.go
@@ -597,7 +597,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Schedule, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -690,7 +690,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Schedule, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -700,7 +700,7 @@ func (fx *ScheduleServiceScheduleTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteSchedule(fx.Context(), &DeleteScheduleRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/specialist_pool_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/specialist_pool_service_aiptest.pb.go
@@ -343,7 +343,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*SpecialistPool, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -436,7 +436,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*SpecialistPool, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -446,7 +446,7 @@ func (fx *SpecialistPoolServiceSpecialistPoolTestSuiteConfig) testList(t *testin
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteSpecialistPool(fx.Context(), &DeleteSpecialistPoolRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/tensorboard_service_aiptest.pb.go
@@ -452,7 +452,7 @@ func (fx *TensorboardServiceTensorboardTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Tensorboard, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -545,7 +545,7 @@ func (fx *TensorboardServiceTensorboardTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Tensorboard, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -555,7 +555,7 @@ func (fx *TensorboardServiceTensorboardTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteTensorboard(fx.Context(), &DeleteTensorboardRequest{
 					Name: parentMsgs[i].Name,
@@ -986,7 +986,7 @@ func (fx *TensorboardServiceTensorboardExperimentTestSuiteConfig) testList(t *te
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*TensorboardExperiment, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1079,7 +1079,7 @@ func (fx *TensorboardServiceTensorboardExperimentTestSuiteConfig) testList(t *te
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*TensorboardExperiment, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1089,7 +1089,7 @@ func (fx *TensorboardServiceTensorboardExperimentTestSuiteConfig) testList(t *te
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteTensorboardExperiment(fx.Context(), &DeleteTensorboardExperimentRequest{
 					Name: parentMsgs[i].Name,
@@ -1589,7 +1589,7 @@ func (fx *TensorboardServiceTensorboardRunTestSuiteConfig) testList(t *testing.T
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*TensorboardRun, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1682,7 +1682,7 @@ func (fx *TensorboardServiceTensorboardRunTestSuiteConfig) testList(t *testing.T
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*TensorboardRun, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1692,7 +1692,7 @@ func (fx *TensorboardServiceTensorboardRunTestSuiteConfig) testList(t *testing.T
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteTensorboardRun(fx.Context(), &DeleteTensorboardRunRequest{
 					Name: parentMsgs[i].Name,
@@ -2208,7 +2208,7 @@ func (fx *TensorboardServiceTensorboardTimeSeriesTestSuiteConfig) testList(t *te
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*TensorboardTimeSeries, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -2301,7 +2301,7 @@ func (fx *TensorboardServiceTensorboardTimeSeriesTestSuiteConfig) testList(t *te
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*TensorboardTimeSeries, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -2311,7 +2311,7 @@ func (fx *TensorboardServiceTensorboardTimeSeriesTestSuiteConfig) testList(t *te
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteTensorboardTimeSeries(fx.Context(), &DeleteTensorboardTimeSeriesRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
+++ b/proto/gen/googleapis/aiplatform/apiv1/aiplatformpb/vizier_service_aiptest.pb.go
@@ -327,7 +327,7 @@ func (fx *VizierServiceStudyTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Study, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -420,7 +420,7 @@ func (fx *VizierServiceStudyTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Study, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -430,7 +430,7 @@ func (fx *VizierServiceStudyTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteStudy(fx.Context(), &DeleteStudyRequest{
 					Name: parentMsgs[i].Name,
@@ -720,7 +720,7 @@ func (fx *VizierServiceTrialTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Trial, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -813,7 +813,7 @@ func (fx *VizierServiceTrialTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Trial, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -823,7 +823,7 @@ func (fx *VizierServiceTrialTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteTrial(fx.Context(), &DeleteTrialRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/area120/tables/apiv1alpha1/tablespb/tables_aiptest.pb.go
+++ b/proto/gen/googleapis/area120/tables/apiv1alpha1/tablespb/tables_aiptest.pb.go
@@ -346,7 +346,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Row, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -439,7 +439,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Row, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -449,7 +449,7 @@ func (fx *TablesServiceRowTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteRow(fx.Context(), &DeleteRowRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/gsuiteaddons/apiv1/gsuiteaddonspb/gsuiteaddons_aiptest.pb.go
+++ b/proto/gen/googleapis/gsuiteaddons/apiv1/gsuiteaddonspb/gsuiteaddons_aiptest.pb.go
@@ -436,7 +436,7 @@ func (fx *GSuiteAddOnsDeploymentTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Deployment, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -529,7 +529,7 @@ func (fx *GSuiteAddOnsDeploymentTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Deployment, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -539,7 +539,7 @@ func (fx *GSuiteAddOnsDeploymentTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteDeployment(fx.Context(), &DeleteDeploymentRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/pubsub/apiv1/pubsubpb/schema_aiptest.pb.go
+++ b/proto/gen/googleapis/pubsub/apiv1/pubsubpb/schema_aiptest.pb.go
@@ -236,7 +236,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Schema, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -329,7 +329,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Schema, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -339,7 +339,7 @@ func (fx *SchemaServiceSchemaTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteSchemaRevision(fx.Context(), &DeleteSchemaRevisionRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/scheduler/apiv1/schedulerpb/cloudscheduler_aiptest.pb.go
+++ b/proto/gen/googleapis/scheduler/apiv1/schedulerpb/cloudscheduler_aiptest.pb.go
@@ -313,7 +313,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Job, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -406,7 +406,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Job, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -416,7 +416,7 @@ func (fx *CloudSchedulerJobTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteJob(fx.Context(), &DeleteJobRequest{
 					Name: parentMsgs[i].Name,

--- a/proto/gen/googleapis/spanner/admin/database/apiv1/databasepb/spanner_database_admin_aiptest.pb.go
+++ b/proto/gen/googleapis/spanner/admin/database/apiv1/databasepb/spanner_database_admin_aiptest.pb.go
@@ -352,7 +352,7 @@ func (fx *DatabaseAdminBackupTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Backup, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -445,7 +445,7 @@ func (fx *DatabaseAdminBackupTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Backup, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -455,7 +455,7 @@ func (fx *DatabaseAdminBackupTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteBackup(fx.Context(), &DeleteBackupRequest{
 					Name: parentMsgs[i].Name,
@@ -788,7 +788,7 @@ func (fx *DatabaseAdminDatabaseTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Database, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -983,7 +983,7 @@ func (fx *DatabaseAdminDatabaseRoleTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*DatabaseRole, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {

--- a/proto/gen/googleapis/spanner/admin/instance/apiv1/instancepb/spanner_instance_admin_aiptest.pb.go
+++ b/proto/gen/googleapis/spanner/admin/instance/apiv1/instancepb/spanner_instance_admin_aiptest.pb.go
@@ -544,7 +544,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Instance, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -637,7 +637,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*Instance, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -647,7 +647,7 @@ func (fx *InstanceAdminInstanceTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteInstance(fx.Context(), &DeleteInstanceRequest{
 					Name: parentMsgs[i].Name,
@@ -1026,7 +1026,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*InstanceConfig, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1119,7 +1119,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*InstanceConfig, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1129,7 +1129,7 @@ func (fx *InstanceAdminInstanceConfigTestSuiteConfig) testList(t *testing.T) {
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteInstanceConfig(fx.Context(), &DeleteInstanceConfigRequest{
 					Name: parentMsgs[i].Name,
@@ -1608,7 +1608,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 	})
 
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*InstancePartition, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1701,7 +1701,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 
 	}
 	{
-		const resourcesCount = 15
+		const resourcesCount = 5
 		parent := fx.nextParent(t, true)
 		parentMsgs := make([]*InstancePartition, resourcesCount)
 		for i := 0; i < resourcesCount; i++ {
@@ -1711,7 +1711,7 @@ func (fx *InstanceAdminInstancePartitionTestSuiteConfig) testList(t *testing.T) 
 		// Method should not return deleted resources.
 		t.Run("deleted", func(t *testing.T) {
 			fx.maybeSkip(t)
-			const deleteCount = 5
+			const deleteCount = 3
 			for i := 0; i < deleteCount; i++ {
 				_, err := fx.Service().DeleteInstancePartition(fx.Context(), &DeleteInstancePartitionRequest{
 					Name: parentMsgs[i].Name,


### PR DESCRIPTION
Speed up generated AIP integration tests by:
- Describe how to use t.Parallel() in config providers to run top-level tests in parallel
- Use (even) fewer items in list tests
- Reduced number of items in delete test to match the list change

Timings in example project with `time go test ./testing/integration/... -count 1` and newly started spanner emulator:
Before: ~52s
After: ~15s

With only the reduction in list items: ~32s
With only t.Parallel(): ~22.5s