### PR TITLE
chore: Update Go and Sage deps to fix linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
         with:
-          go-version-file: go.mod
+          go-version-file: .sage/go.mod
 
       - name: Make
         run: make

--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -1,5 +1,5 @@
 module sage
 
-go 1.23
+go 1.25.7
 
-require go.einride.tech/sage v0.371.0
+require go.einride.tech/sage v0.409.0

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.371.0 h1:uRoKhO2l6ZJd0x+jdqkL/FPy7N5NKZIb2SGkENwmyx8=
-go.einride.tech/sage v0.371.0/go.mod h1:sy9YuK//XVwEZ2wD3f19xVSKEtN8CYtgtBZGpzC3p80=
+go.einride.tech/sage v0.409.0 h1:o4hqjRPH1EO8XZsUcfA8E9p3HWlu3X19wPf9p8hY8YM=
+go.einride.tech/sage v0.409.0/go.mod h1:k/GWZv8EP64DxdCSZt9GIYMgOCxntdfE6FTRTIzQVdE=

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -11,7 +11,7 @@ import (
 	"go.einride.tech/sage/tools/sgconvco"
 	"go.einride.tech/sage/tools/sggit"
 	"go.einride.tech/sage/tools/sggo"
-	"go.einride.tech/sage/tools/sggolangcilint"
+	"go.einride.tech/sage/tools/sggolangcilintv2"
 	"go.einride.tech/sage/tools/sggoreleaser"
 	"go.einride.tech/sage/tools/sggosemanticrelease"
 	"go.einride.tech/sage/tools/sgmdformat"
@@ -59,7 +59,7 @@ func FormatMarkdown(ctx context.Context) error {
 
 func GoLint(ctx context.Context) error {
 	sg.Logger(ctx).Println("linting Go files...")
-	return sggolangcilint.Run(ctx)
+	return sggolangcilintv2.Run(ctx, sggolangcilintv2.Config{})
 }
 
 func GoModTidy(ctx context.Context) error {
@@ -90,7 +90,7 @@ func ReadmeSnippet(ctx context.Context) error {
 	if !usageRegexp.Match(readme) {
 		return fmt.Errorf("found no match for 'suites' snippet in README.md")
 	}
-	return os.WriteFile("README.md", usageRegexp.ReplaceAll(readme, []byte(suites)), 0o600)
+	return os.WriteFile("README.md", usageRegexp.ReplaceAll(readme, []byte(suites)), 0o600) //nolint:gosec
 }
 
 func SemanticRelease(ctx context.Context, repo string, dry bool) error {

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sagefile := $(abspath $(cwd)/.sage/bin/sagefile)
 go := $(shell command -v go 2>/dev/null)
 export GOWORK ?= off
 ifndef go
-SAGE_GO_VERSION ?= 1.23.4
+SAGE_GO_VERSION ?= 1.25.7
 export GOROOT := $(abspath $(cwd)/.sage/tools/go/$(SAGE_GO_VERSION)/go)
 export PATH := $(PATH):$(GOROOT)/bin
 go := $(GOROOT)/bin/go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/einride/protoc-gen-go-aip-test
 
-go 1.23
+go 1.25.7
 
 require (
 	cloud.google.com/go/iam v1.2.1

--- a/internal/aiptest/create/resource_references.go
+++ b/internal/aiptest/create/resource_references.go
@@ -75,7 +75,14 @@ var resourceReferences = suite.Test{
 					Parent:   "parent",
 					Message:  "msg",
 				}.Generate(f, "_", "err", ":=")
-				f.P(ident.AssertEqual, "(t, ", ident.Codes(codes.InvalidArgument), ", ", ident.StatusCode, "(err), err)")
+				f.P(
+					ident.AssertEqual,
+					"(t, ",
+					ident.Codes(codes.InvalidArgument),
+					", ",
+					ident.StatusCode,
+					"(err), err)",
+				)
 				f.P("})")
 			},
 		)

--- a/internal/plugin/resource.go
+++ b/internal/plugin/resource.go
@@ -140,7 +140,15 @@ func (r *resourceGenerator) generateTestCases(f *protogen.GeneratedFile) error {
 		if !s.Enabled(scope) {
 			continue
 		}
-		f.P("func (fx *", resourceTestSuiteConfigName(r.service.Desc, r.resource), ") test", s.Name, "(t *", testingT, ") {")
+		f.P(
+			"func (fx *",
+			resourceTestSuiteConfigName(r.service.Desc, r.resource),
+			") test",
+			s.Name,
+			"(t *",
+			testingT,
+			") {",
+		)
 		f.P(ident.FixtureMaybeSkip, "(t)")
 		for _, t := range s.Tests {
 			if !t.Enabled(scope) {

--- a/internal/util/method.go
+++ b/internal/util/method.go
@@ -25,7 +25,18 @@ func (m MethodCreate) Generate(f *protogen.GeneratedFile, response, err, assign 
 		f.P("}")
 	}
 
-	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
+	f.P(
+		response,
+		", ",
+		err,
+		" ",
+		assign,
+		" fx.Service().",
+		m.Method.GoName,
+		"(fx.Context(), &",
+		m.Method.Input.GoIdent,
+		"{",
+	)
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -59,7 +70,18 @@ type MethodGet struct {
 }
 
 func (m MethodGet) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
+	f.P(
+		response,
+		", ",
+		err,
+		" ",
+		assign,
+		" fx.Service().",
+		m.Method.GoName,
+		"(fx.Context(), &",
+		m.Method.Input.GoIdent,
+		"{",
+	)
 	f.P("Name: ", m.Name, ",")
 	f.P("})")
 }
@@ -73,7 +95,18 @@ type MethodBatchGet struct {
 }
 
 func (m MethodBatchGet) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
+	f.P(
+		response,
+		", ",
+		err,
+		" ",
+		assign,
+		" fx.Service().",
+		m.Method.GoName,
+		"(fx.Context(), &",
+		m.Method.Input.GoIdent,
+		"{",
+	)
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -120,7 +153,18 @@ func (m MethodUpdate) Generate(f *protogen.GeneratedFile, response, err, assign 
 			f.P(`msg.Etag = created.Etag // assign etag from the created resource`)
 		}
 	}
-	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
+	f.P(
+		response,
+		", ",
+		err,
+		" ",
+		assign,
+		" fx.Service().",
+		m.Method.GoName,
+		"(fx.Context(), &",
+		m.Method.Input.GoIdent,
+		"{",
+	)
 	if m.Msg != "" {
 		f.P(upper, ":", m.Msg, ",")
 	} else {
@@ -163,7 +207,18 @@ type MethodList struct {
 }
 
 func (m MethodList) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
+	f.P(
+		response,
+		", ",
+		err,
+		" ",
+		assign,
+		" fx.Service().",
+		m.Method.GoName,
+		"(fx.Context(), &",
+		m.Method.Input.GoIdent,
+		"{",
+	)
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -186,7 +241,18 @@ type MethodSearch struct {
 }
 
 func (m MethodSearch) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
+	f.P(
+		response,
+		", ",
+		err,
+		" ",
+		assign,
+		" fx.Service().",
+		m.Method.GoName,
+		"(fx.Context(), &",
+		m.Method.Input.GoIdent,
+		"{",
+	)
 	if HasParent(m.Resource) {
 		f.P("Parent: ", m.Parent, ",")
 	}
@@ -209,7 +275,18 @@ type MethodDelete struct {
 }
 
 func (m MethodDelete) Generate(f *protogen.GeneratedFile, response, err, assign string) {
-	f.P(response, ", ", err, " ", assign, " fx.Service().", m.Method.GoName, "(fx.Context(), &", m.Method.Input.GoIdent, "{") //nolint:lll
+	f.P(
+		response,
+		", ",
+		err,
+		" ",
+		assign,
+		" fx.Service().",
+		m.Method.GoName,
+		"(fx.Context(), &",
+		m.Method.Input.GoIdent,
+		"{",
+	)
 	if m.Name != "" {
 		f.P("Name: ", m.Name, ",")
 	} else {

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -10,7 +10,7 @@ sagefile := $(abspath $(cwd)/../.sage/bin/sagefile)
 go := $(shell command -v go 2>/dev/null)
 export GOWORK ?= off
 ifndef go
-SAGE_GO_VERSION ?= 1.23.4
+SAGE_GO_VERSION ?= 1.25.7
 export GOROOT := $(abspath $(cwd)/../.sage/tools/go/$(SAGE_GO_VERSION)/go)
 export PATH := $(PATH):$(GOROOT)/bin
 go := $(GOROOT)/bin/go


### PR DESCRIPTION
Upgrade to sggolangcilintv2, bump Go and sage version and fix some long lines to make the linter happy.

Resolves this build error:
[go-lint] ../../../../sdk/go1.26.2/src/vendor/golang.org/x/crypto/chacha20poly1305/fips140only_go1.26.go:7:9: file requires newer Go version go1.26 (application built with go1.24) (typecheck)
[go-lint] package chacha20poly1305